### PR TITLE
Remove filtering logic from TreeStringRenderer and use collections instead.

### DIFF
--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -64,14 +64,8 @@ object Radiography {
         viewToString(node, includeTextViewText, textViewTextMaxLength)
       }
 
-      override fun View.getChildAt(index: Int): View? {
-        return if (this is ViewGroup) getChildAt(index) else null
-      }
-
-      override val View.childCount: Int
-        get() = if (this is ViewGroup) childCount else 0
-
-      override fun View.matches() = viewFilter.matches(this)
+      override val View.children: Collection<View?>
+        get() = if (this is ViewGroup) childrenAsList().filter(viewFilter::matches) else emptyList()
     }
 
     for (view in matchingRootViews) {

--- a/radiography/src/main/java/radiography/Views.kt
+++ b/radiography/src/main/java/radiography/Views.kt
@@ -1,6 +1,7 @@
 package radiography
 
 import android.view.View
+import android.view.ViewGroup
 
 /**
  * Extension function for [Radiography.scan] when scanning starts from a specific view.
@@ -17,4 +18,9 @@ fun View?.scan(
   } else {
     Radiography.scan(this, includeTextViewText, textViewTextMaxLength, viewFilter)
   }
+}
+
+internal fun ViewGroup.childrenAsList(): List<View> = object : AbstractList<View>() {
+  override val size: Int get() = childCount
+  override fun get(index: Int): View = getChildAt(index)
 }


### PR DESCRIPTION
Filtering logic doesn't belong in the renderer, and while this is slightly less efficient, it shouldn't be significant.