### PR TITLE
Run UI tests on CI.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,3 +23,36 @@ jobs:
         java-version: 1.8
     - name: Build with Gradle
       run: ./gradlew build -Dsquare.kotlinVersion=${{ matrix.kotlin-version }}
+
+  instrumentation-tests:
+    name: Instrumentation tests
+    runs-on: macos-latest
+    timeout-minutes: 20
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level:
+          - 21
+          - 23
+          - 26
+          - 29
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Instrumentation Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          script: ./gradlew connectedCheck --no-build-cache --no-daemon --stacktrace
+
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: insrumentation-test-results
+          path: ./**/build/reports/androidTests/connected/**


### PR DESCRIPTION
Since this is a UI library, configured to run tests on 4 devices, starting at SDK level 21. They'll all run in parallel.