### PR TITLE
Change ViewFilter input from View to Any.

### DIFF
--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -6,7 +6,7 @@ public final class radiography/AttributeAppendable {
 public final class radiography/FocusedWindowViewFilter : radiography/ViewFilter {
 	public static final field INSTANCE Lradiography/FocusedWindowViewFilter;
 	public fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
-	public fun matches (Landroid/view/View;)Z
+	public fun matches (Ljava/lang/Object;)Z
 }
 
 public final class radiography/Radiography {
@@ -18,7 +18,7 @@ public final class radiography/Radiography {
 public final class radiography/SkipIdsViewFilter : radiography/ViewFilter {
 	public fun <init> ([I)V
 	public fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
-	public fun matches (Landroid/view/View;)Z
+	public fun matches (Ljava/lang/Object;)Z
 }
 
 public final class radiography/StateRenderer {
@@ -32,13 +32,13 @@ public final class radiography/StateRenderer$Companion {
 
 public abstract interface class radiography/ViewFilter {
 	public abstract fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
-	public abstract fun matches (Landroid/view/View;)Z
+	public abstract fun matches (Ljava/lang/Object;)Z
 }
 
 public final class radiography/ViewFilter$All : radiography/ViewFilter {
 	public static final field INSTANCE Lradiography/ViewFilter$All;
 	public fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
-	public fun matches (Landroid/view/View;)Z
+	public fun matches (Ljava/lang/Object;)Z
 }
 
 public final class radiography/ViewFilter$DefaultImpls {

--- a/radiography/src/main/java/radiography/FocusedWindowViewFilter.kt
+++ b/radiography/src/main/java/radiography/FocusedWindowViewFilter.kt
@@ -7,7 +7,7 @@ import android.view.View
  */
 object FocusedWindowViewFilter : ViewFilter {
 
-  override fun matches(view: View): Boolean {
-    return view.parent?.parent != null || view.hasWindowFocus()
+  override fun matches(view: Any): Boolean {
+    return view is View && (view.parent?.parent != null || view.hasWindowFocus())
   }
 }

--- a/radiography/src/main/java/radiography/SkipIdsViewFilter.kt
+++ b/radiography/src/main/java/radiography/SkipIdsViewFilter.kt
@@ -7,7 +7,8 @@ import android.view.View
  */
 class SkipIdsViewFilter(private vararg val skippedIds: Int) : ViewFilter {
 
-  override fun matches(view: View): Boolean {
+  override fun matches(view: Any): Boolean {
+    if (view !is View) return false
     val viewId = view.id
     return (viewId == View.NO_ID || skippedIds.isEmpty() || skippedIds.binarySearch(viewId) < 0)
   }

--- a/radiography/src/main/java/radiography/ViewFilter.kt
+++ b/radiography/src/main/java/radiography/ViewFilter.kt
@@ -1,7 +1,5 @@
 package radiography
 
-import android.view.View
-
 /**
  * Used to filter out views from the output of [Radiography.scan].
  */
@@ -9,10 +7,10 @@ interface ViewFilter {
   /**
    * @return true to keep the view in the output of [Radiography.scan], false to filter it out.
    */
-  fun matches(view: View): Boolean
+  fun matches(view: Any): Boolean
 
   object All : ViewFilter {
-    override fun matches(view: View) = true
+    override fun matches(view: Any) = true
   }
 
   /**
@@ -21,7 +19,7 @@ interface ViewFilter {
   infix fun and(otherFilter: ViewFilter): ViewFilter {
     val thisFilter = this
     return object : ViewFilter {
-      override fun matches(view: View) = thisFilter.matches(view) &&
+      override fun matches(view: Any) = thisFilter.matches(view) &&
           otherFilter.matches(view)
     }
   }

--- a/radiography/src/test/java/radiography/RadiographyTest.kt
+++ b/radiography/src/test/java/radiography/RadiographyTest.kt
@@ -126,7 +126,7 @@ class RadiographyTest {
     layout.addView(EditText(context))
 
     val filter = SkipIdsViewFilter(42) and object : ViewFilter {
-      override fun matches(view: View) = view !is EditText
+      override fun matches(view: Any) = view !is EditText
     }
     layout.scan(viewFilter = filter)
         .also {

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -44,7 +44,7 @@ class MainActivity : Activity() {
         },
         "Focused window and custom filter" to {
           Radiography.scan(viewFilter = FocusedWindowViewFilter and object : ViewFilter {
-            override fun matches(view: View) = view !is LinearLayout
+            override fun matches(view: Any) = view !is LinearLayout
           })
         },
         "Include PII" to {


### PR DESCRIPTION
This allows us to write filters that match whatever the node type is
for composables as well, without having a separate filter type.