### PR TITLE
Polish the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ val prettyHierarchy = Radiography.scan(stateRenderers = defaultsIncludingPii)
 
 // Append custom attribute rendering
 val prettyHierarchy = Radiography.scan(stateRenderers = defaultsNoPii +
-    stateRendererFor<LinearLayout> {
+    viewStateRendererFor<LinearLayout> {
       append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
     })
 ```
@@ -103,7 +103,7 @@ Button { id:show_dialog, 652x126px, text-length:28 }
 If you'd rather rely on View.toString(), you can provide a custom state renderer.
 
 ```kotlin
-val prettyHierarchy = Radiography.scan(stateRenderers = listOf(stateRendererFor<View> {
+val prettyHierarchy = Radiography.scan(stateRenderers = listOf(viewStateRendererFor<View> {
   append(
       it.toString()
           .substringAfter(' ')

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ dependencies {
 val prettyHierarchy = Radiography.scan()
 
 // Include the text content from TextView instances.
-val prettyHierarchy = Radiography.scan(stateRenderers = defaultsIncludingPii)
+val prettyHierarchy = Radiography.scan(stateRenderers = DefaultsIncludingPii)
 
 // Append custom attribute rendering
-val prettyHierarchy = Radiography.scan(stateRenderers = defaultsNoPii +
+val prettyHierarchy = Radiography.scan(stateRenderers = DefaultsNoPii +
     viewStateRendererFor<LinearLayout> {
       append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
     })

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -45,15 +45,15 @@ public final class radiography/ViewStateRenderer {
 }
 
 public final class radiography/ViewStateRenderers {
+	public static final field CheckableRenderer Lradiography/ViewStateRenderer;
+	public static final field DefaultsIncludingPii Ljava/util/List;
+	public static final field DefaultsNoPii Ljava/util/List;
 	public static final field INSTANCE Lradiography/ViewStateRenderers;
-	public final fun getCheckableRenderer ()Lradiography/ViewStateRenderer;
-	public final fun getDefaultsIncludingPii ()Ljava/util/List;
-	public final fun getDefaultsNoPii ()Ljava/util/List;
-	public final fun getViewRenderer ()Lradiography/ViewStateRenderer;
-	public final fun textViewRenderer ()Lradiography/ViewStateRenderer;
-	public final fun textViewRenderer (Z)Lradiography/ViewStateRenderer;
-	public final fun textViewRenderer (ZI)Lradiography/ViewStateRenderer;
-	public static synthetic fun textViewRenderer$default (Lradiography/ViewStateRenderers;ZIILjava/lang/Object;)Lradiography/ViewStateRenderer;
+	public static final field ViewRenderer Lradiography/ViewStateRenderer;
+	public static final fun textViewRenderer ()Lradiography/ViewStateRenderer;
+	public static final fun textViewRenderer (Z)Lradiography/ViewStateRenderer;
+	public static final fun textViewRenderer (ZI)Lradiography/ViewStateRenderer;
+	public static synthetic fun textViewRenderer$default (ZIILjava/lang/Object;)Lradiography/ViewStateRenderer;
 }
 
 public final class radiography/ViewsKt {

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -5,7 +5,6 @@ public final class radiography/AttributeAppendable {
 
 public final class radiography/FocusedWindowViewFilter : radiography/ViewFilter {
 	public static final field INSTANCE Lradiography/FocusedWindowViewFilter;
-	public fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
 	public fun matches (Ljava/lang/Object;)Z
 }
 
@@ -20,23 +19,20 @@ public final class radiography/Radiography {
 
 public final class radiography/SkipIdsViewFilter : radiography/ViewFilter {
 	public fun <init> ([I)V
-	public fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
 	public fun matches (Ljava/lang/Object;)Z
 }
 
 public abstract interface class radiography/ViewFilter {
-	public abstract fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
 	public abstract fun matches (Ljava/lang/Object;)Z
 }
 
 public final class radiography/ViewFilter$All : radiography/ViewFilter {
 	public static final field INSTANCE Lradiography/ViewFilter$All;
-	public fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
 	public fun matches (Ljava/lang/Object;)Z
 }
 
-public final class radiography/ViewFilter$DefaultImpls {
-	public static fun and (Lradiography/ViewFilter;Lradiography/ViewFilter;)Lradiography/ViewFilter;
+public final class radiography/ViewFilters {
+	public static final fun and (Lradiography/ViewFilter;Lradiography/ViewFilter;)Lradiography/ViewFilter;
 }
 
 public final class radiography/ViewStateRenderer {

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -21,15 +21,6 @@ public final class radiography/SkipIdsViewFilter : radiography/ViewFilter {
 	public fun matches (Ljava/lang/Object;)Z
 }
 
-public final class radiography/StateRenderer {
-	public static final field Companion Lradiography/StateRenderer$Companion;
-	public fun <init> (Ljava/lang/Class;Lkotlin/jvm/functions/Function2;)V
-	public final fun appendAttributes (Lradiography/AttributeAppendable;Ljava/lang/Object;)V
-}
-
-public final class radiography/StateRenderer$Companion {
-}
-
 public abstract interface class radiography/ViewFilter {
 	public abstract fun and (Lradiography/ViewFilter;)Lradiography/ViewFilter;
 	public abstract fun matches (Ljava/lang/Object;)Z
@@ -45,14 +36,19 @@ public final class radiography/ViewFilter$DefaultImpls {
 	public static fun and (Lradiography/ViewFilter;Lradiography/ViewFilter;)Lradiography/ViewFilter;
 }
 
+public final class radiography/ViewStateRenderer {
+	public fun <init> (Ljava/lang/Class;Lkotlin/jvm/functions/Function2;)V
+	public final fun appendAttributes (Lradiography/AttributeAppendable;Ljava/lang/Object;)V
+}
+
 public final class radiography/ViewStateRenderers {
 	public static final field INSTANCE Lradiography/ViewStateRenderers;
-	public final fun getCheckableRenderer ()Lradiography/StateRenderer;
+	public final fun getCheckableRenderer ()Lradiography/ViewStateRenderer;
 	public final fun getDefaultsIncludingPii ()Ljava/util/List;
 	public final fun getDefaultsNoPii ()Ljava/util/List;
-	public final fun getViewRenderer ()Lradiography/StateRenderer;
-	public final fun textViewRenderer (ZI)Lradiography/StateRenderer;
-	public static synthetic fun textViewRenderer$default (Lradiography/ViewStateRenderers;ZIILjava/lang/Object;)Lradiography/StateRenderer;
+	public final fun getViewRenderer ()Lradiography/ViewStateRenderer;
+	public final fun textViewRenderer (ZI)Lradiography/ViewStateRenderer;
+	public static synthetic fun textViewRenderer$default (Lradiography/ViewStateRenderers;ZIILjava/lang/Object;)Lradiography/ViewStateRenderer;
 }
 
 public final class radiography/ViewsKt {

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -11,6 +11,9 @@ public final class radiography/FocusedWindowViewFilter : radiography/ViewFilter 
 
 public final class radiography/Radiography {
 	public static final field INSTANCE Lradiography/Radiography;
+	public static final fun scan ()Ljava/lang/String;
+	public static final fun scan (Landroid/view/View;)Ljava/lang/String;
+	public static final fun scan (Landroid/view/View;Ljava/util/List;)Ljava/lang/String;
 	public static final fun scan (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;)Ljava/lang/String;
 	public static synthetic fun scan$default (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;ILjava/lang/Object;)Ljava/lang/String;
 }
@@ -47,6 +50,8 @@ public final class radiography/ViewStateRenderers {
 	public final fun getDefaultsIncludingPii ()Ljava/util/List;
 	public final fun getDefaultsNoPii ()Ljava/util/List;
 	public final fun getViewRenderer ()Lradiography/ViewStateRenderer;
+	public final fun textViewRenderer ()Lradiography/ViewStateRenderer;
+	public final fun textViewRenderer (Z)Lradiography/ViewStateRenderer;
 	public final fun textViewRenderer (ZI)Lradiography/ViewStateRenderer;
 	public static synthetic fun textViewRenderer$default (Lradiography/ViewStateRenderers;ZIILjava/lang/Object;)Lradiography/ViewStateRenderer;
 }

--- a/radiography/src/androidTest/java/radiography/test/RadiographyUiTest.kt
+++ b/radiography/src/androidTest/java/radiography/test/RadiographyUiTest.kt
@@ -11,7 +11,7 @@ import org.junit.Rule
 import org.junit.Test
 import radiography.FocusedWindowViewFilter
 import radiography.Radiography
-import radiography.ViewStateRenderers.defaultsIncludingPii
+import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.test.utilities.TestActivity
 import radiography.test.utilities.TestActivity.Companion.withTextViewText
 import java.util.concurrent.CountDownLatch
@@ -39,7 +39,7 @@ class RadiographyUiTest {
   @Test fun when_includingPii_then_hierarchyContainsText() {
     activityRule.launchActivity(Intent().withTextViewText("Yo"))
 
-    val hierarchy = Radiography.scan(viewStateRenderers = defaultsIncludingPii)
+    val hierarchy = Radiography.scan(viewStateRenderers = DefaultsIncludingPii)
     assertThat(hierarchy).contains("Yo")
   }
 
@@ -65,8 +65,10 @@ class RadiographyUiTest {
           .create()
     }
 
-    val hierarchy =
-      Radiography.scan(viewStateRenderers = defaultsIncludingPii, viewFilter = FocusedWindowViewFilter)
+    val hierarchy = Radiography.scan(
+        viewStateRenderers = DefaultsIncludingPii,
+        viewFilter = FocusedWindowViewFilter
+    )
 
     assertThat(hierarchy).contains("window-focus:true")
     assertThat(hierarchy).contains("Dialog title")

--- a/radiography/src/androidTest/java/radiography/test/RadiographyUiTest.kt
+++ b/radiography/src/androidTest/java/radiography/test/RadiographyUiTest.kt
@@ -39,7 +39,7 @@ class RadiographyUiTest {
   @Test fun when_includingPii_then_hierarchyContainsText() {
     activityRule.launchActivity(Intent().withTextViewText("Yo"))
 
-    val hierarchy = Radiography.scan(stateRenderers = defaultsIncludingPii)
+    val hierarchy = Radiography.scan(viewStateRenderers = defaultsIncludingPii)
     assertThat(hierarchy).contains("Yo")
   }
 
@@ -66,7 +66,7 @@ class RadiographyUiTest {
     }
 
     val hierarchy =
-      Radiography.scan(stateRenderers = defaultsIncludingPii, viewFilter = FocusedWindowViewFilter)
+      Radiography.scan(viewStateRenderers = defaultsIncludingPii, viewFilter = FocusedWindowViewFilter)
 
     assertThat(hierarchy).contains("window-focus:true")
     assertThat(hierarchy).contains("Dialog title")

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -37,6 +37,7 @@ object Radiography {
    * views of the currently focused window, if any.
    */
   @JvmStatic
+  @JvmOverloads
   fun scan(
     rootView: View? = null,
     viewStateRenderers: List<ViewStateRenderer<*>> = defaultsNoPii,

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -5,7 +5,7 @@ import android.os.Looper
 import android.view.View
 import android.view.WindowManager
 import radiography.Radiography.scan
-import radiography.ViewStateRenderers.defaultsNoPii
+import radiography.ViewStateRenderers.DefaultsNoPii
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.atomic.AtomicReference
@@ -40,7 +40,7 @@ object Radiography {
   @JvmOverloads
   fun scan(
     rootView: View? = null,
-    viewStateRenderers: List<ViewStateRenderer<*>> = defaultsNoPii,
+    viewStateRenderers: List<ViewStateRenderer<*>> = DefaultsNoPii,
     viewFilter: ViewFilter = ViewFilter.All
   ): String {
 

--- a/radiography/src/main/java/radiography/ViewFilter.kt
+++ b/radiography/src/main/java/radiography/ViewFilter.kt
@@ -1,3 +1,4 @@
+@file:JvmName("ViewFilters")
 package radiography
 
 /**
@@ -12,15 +13,15 @@ interface ViewFilter {
   object All : ViewFilter {
     override fun matches(view: Any) = true
   }
+}
 
-  /**
-   * Creates a new filter that combines this filter with [otherFilter]
-   */
-  infix fun and(otherFilter: ViewFilter): ViewFilter {
-    val thisFilter = this
-    return object : ViewFilter {
-      override fun matches(view: Any) = thisFilter.matches(view) &&
-          otherFilter.matches(view)
-    }
+/**
+ * Creates a new filter that combines this filter with [otherFilter]
+ */
+infix fun ViewFilter.and(otherFilter: ViewFilter): ViewFilter {
+  val thisFilter = this
+  return object : ViewFilter {
+    override fun matches(view: Any) = thisFilter.matches(view) &&
+        otherFilter.matches(view)
   }
 }

--- a/radiography/src/main/java/radiography/ViewStateRenderer.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderer.kt
@@ -1,17 +1,15 @@
 package radiography
 
-import radiography.StateRenderer.Companion.stateRendererFor
-
 /**
  * Renders extra attributes for specifics types in the output of [Radiography.scan].
- * Call [stateRendererFor] to create instances with reified types:
+ * Call [viewStateRendererFor] to create instances with reified types:
  * ```
- *  val myRenderer: StateRenderer<MyView> = stateRendererFor {
+ *  val myRenderer: StateRenderer<MyView> = viewStateRendererFor {
  *    append(it.customAttributeValue)
  *  }
  * ```
  */
-class StateRenderer<in T> @PublishedApi internal constructor(
+class ViewStateRenderer<in T> @PublishedApi internal constructor(
   private val renderedClass: Class<T>,
   private val renderer: AttributeAppendable.(T) -> Unit
 ) {
@@ -27,9 +25,7 @@ class StateRenderer<in T> @PublishedApi internal constructor(
       }
     }
   }
-
-  companion object {
-    inline fun <reified T> stateRendererFor(noinline renderer: AttributeAppendable.(T) -> Unit) =
-      StateRenderer(T::class.java, renderer)
-  }
 }
+
+inline fun <reified T> viewStateRendererFor(noinline renderer: AttributeAppendable.(T) -> Unit) =
+  ViewStateRenderer(T::class.java, renderer)

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -63,6 +63,7 @@ object ViewStateRenderers {
    * [includeTextViewText] is true. When the max size is reached, the text is trimmed to
    * a [textViewTextMaxLength] - 1 length and ellipsized with a '…' character.
    */
+  @JvmOverloads
   fun textViewRenderer(
     includeTextViewText: Boolean = false,
     textViewTextMaxLength: Int = Int.MAX_VALUE

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -4,11 +4,10 @@ import android.content.res.Resources.NotFoundException
 import android.view.View
 import android.widget.Checkable
 import android.widget.TextView
-import radiography.StateRenderer.Companion.stateRendererFor
 
 object ViewStateRenderers {
 
-  val viewRenderer: StateRenderer<View> = stateRendererFor { view ->
+  val viewRenderer: ViewStateRenderer<View> = viewStateRendererFor { view ->
     if (view.id != View.NO_ID && view.resources != null) {
       try {
         val resourceName = view.resources.getResourceEntryName(view.id)
@@ -38,19 +37,19 @@ object ViewStateRenderers {
     }
   }
 
-  val checkableRenderer: StateRenderer<Checkable> = stateRendererFor { checkable ->
+  val checkableRenderer: ViewStateRenderer<Checkable> = viewStateRendererFor { checkable ->
     if (checkable.isChecked) {
       append("checked")
     }
   }
 
-  val defaultsNoPii: List<StateRenderer<*>> = listOf(
+  val defaultsNoPii: List<ViewStateRenderer<*>> = listOf(
       viewRenderer,
       textViewRenderer(includeTextViewText = false, textViewTextMaxLength = 0),
       checkableRenderer
   )
 
-  val defaultsIncludingPii: List<StateRenderer<*>> = listOf(
+  val defaultsIncludingPii: List<ViewStateRenderer<*>> = listOf(
       viewRenderer,
       textViewRenderer(includeTextViewText = true),
       checkableRenderer
@@ -67,13 +66,13 @@ object ViewStateRenderers {
   fun textViewRenderer(
     includeTextViewText: Boolean = false,
     textViewTextMaxLength: Int = Int.MAX_VALUE
-  ): StateRenderer<TextView> {
+  ): ViewStateRenderer<TextView> {
     if (includeTextViewText) {
       check(textViewTextMaxLength >= 0) {
         "textFieldMaxLength should be greater than 0, not $textViewTextMaxLength"
       }
     }
-    return stateRendererFor { textView ->
+    return viewStateRendererFor { textView ->
       var text = textView.text
       if (text != null) {
         append("text-length:${text.length}")

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -7,7 +7,8 @@ import android.widget.TextView
 
 object ViewStateRenderers {
 
-  val viewRenderer: ViewStateRenderer<View> = viewStateRendererFor { view ->
+  @JvmField
+  val ViewRenderer: ViewStateRenderer<View> = viewStateRendererFor { view ->
     if (view.id != View.NO_ID && view.resources != null) {
       try {
         val resourceName = view.resources.getResourceEntryName(view.id)
@@ -37,22 +38,25 @@ object ViewStateRenderers {
     }
   }
 
-  val checkableRenderer: ViewStateRenderer<Checkable> = viewStateRendererFor { checkable ->
+  @JvmField
+  val CheckableRenderer: ViewStateRenderer<Checkable> = viewStateRendererFor { checkable ->
     if (checkable.isChecked) {
       append("checked")
     }
   }
 
-  val defaultsNoPii: List<ViewStateRenderer<*>> = listOf(
-      viewRenderer,
+  @JvmField
+  val DefaultsNoPii: List<ViewStateRenderer<*>> = listOf(
+      ViewRenderer,
       textViewRenderer(includeTextViewText = false, textViewTextMaxLength = 0),
-      checkableRenderer
+      CheckableRenderer
   )
 
-  val defaultsIncludingPii: List<ViewStateRenderer<*>> = listOf(
-      viewRenderer,
+  @JvmField
+  val DefaultsIncludingPii: List<ViewStateRenderer<*>> = listOf(
+      ViewRenderer,
       textViewRenderer(includeTextViewText = true),
-      checkableRenderer
+      CheckableRenderer
   )
 
   /**
@@ -63,6 +67,7 @@ object ViewStateRenderers {
    * [includeTextViewText] is true. When the max size is reached, the text is trimmed to
    * a [textViewTextMaxLength] - 1 length and ellipsized with a '…' character.
    */
+  @JvmStatic
   @JvmOverloads
   fun textViewRenderer(
     includeTextViewText: Boolean = false,

--- a/radiography/src/main/java/radiography/ViewTreeRenderingVisitor.kt
+++ b/radiography/src/main/java/radiography/ViewTreeRenderingVisitor.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 
 /**
  * A [TreeRenderingVisitor] that renders [View]s and their children which match [viewFilter] using
- * [stateRenderers].
+ * [viewStateRenderers].
  */
 internal class ViewTreeRenderingVisitor(
-  private val stateRenderers: List<StateRenderer<*>>,
+  private val viewStateRenderers: List<ViewStateRenderer<*>>,
   private val viewFilter: ViewFilter
 ) : TreeRenderingVisitor<View>() {
 
@@ -35,7 +35,7 @@ internal class ViewTreeRenderingVisitor(
   private fun StringBuilder.viewToString(view: View) {
     append("${view.javaClass.simpleName} { ")
     val appendable = AttributeAppendable(this)
-    for (renderer in stateRenderers) {
+    for (renderer in viewStateRenderers) {
       renderer.appendAttributes(appendable, view)
     }
     append(" }")

--- a/radiography/src/main/java/radiography/Views.kt
+++ b/radiography/src/main/java/radiography/Views.kt
@@ -1,7 +1,7 @@
 package radiography
 
 import android.view.View
-import radiography.ViewStateRenderers.defaultsNoPii
+import radiography.ViewStateRenderers.DefaultsNoPii
 
 /**
  * Extension function for [Radiography.scan] when scanning starts from a specific view.
@@ -9,7 +9,7 @@ import radiography.ViewStateRenderers.defaultsNoPii
  */
 @JvmSynthetic
 fun View?.scan(
-  viewStateRenderers: List<ViewStateRenderer<*>> = defaultsNoPii,
+  viewStateRenderers: List<ViewStateRenderer<*>> = DefaultsNoPii,
   viewFilter: ViewFilter = ViewFilter.All
 ): String {
   return if (this == null) {

--- a/radiography/src/main/java/radiography/Views.kt
+++ b/radiography/src/main/java/radiography/Views.kt
@@ -9,12 +9,12 @@ import radiography.ViewStateRenderers.defaultsNoPii
  */
 @JvmSynthetic
 fun View?.scan(
-  stateRenderers: List<StateRenderer<*>> = defaultsNoPii,
+  viewStateRenderers: List<ViewStateRenderer<*>> = defaultsNoPii,
   viewFilter: ViewFilter = ViewFilter.All
 ): String {
   return if (this == null) {
     "null"
   } else {
-    Radiography.scan(this, stateRenderers, viewFilter)
+    Radiography.scan(this, viewStateRenderers, viewFilter)
   }
 }

--- a/radiography/src/test/java/radiography/RadiographyTest.kt
+++ b/radiography/src/test/java/radiography/RadiographyTest.kt
@@ -66,7 +66,7 @@ class RadiographyTest {
   @Test fun textViewContents() {
     val view = TextView(context)
     view.text = "Baguette Avec Fromage"
-    view.scan(stateRenderers = listOf(textViewRenderer(includeTextViewText = true)))
+    view.scan(viewStateRenderers = listOf(textViewRenderer(includeTextViewText = true)))
         .also {
           assertThat(it).contains("text-length:21")
           assertThat(it).contains("text:\"Baguette Avec Fromage\"")
@@ -77,7 +77,7 @@ class RadiographyTest {
     val view = TextView(context)
     view.text = "Baguette Avec Fromage"
     view.scan(
-        stateRenderers = listOf(
+        viewStateRenderers = listOf(
             textViewRenderer(
                 includeTextViewText = true,
                 textViewTextMaxLength = 11

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -12,12 +12,12 @@ import android.widget.TextView
 import radiography.FocusedWindowViewFilter
 import radiography.Radiography
 import radiography.SkipIdsViewFilter
-import radiography.StateRenderer.Companion.stateRendererFor
 import radiography.ViewFilter
 import radiography.ViewStateRenderers
 import radiography.ViewStateRenderers.defaultsIncludingPii
 import radiography.ViewStateRenderers.defaultsNoPii
 import radiography.scan
+import radiography.viewStateRendererFor
 
 class MainActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -49,12 +49,12 @@ class MainActivity : Activity() {
         },
         "Include PII" to {
           Radiography.scan(
-              stateRenderers = defaultsIncludingPii
+              viewStateRenderers = defaultsIncludingPii
           )
         },
         "Include PII ellipsized" to {
           Radiography.scan(
-              stateRenderers = listOf(
+              viewStateRenderers = listOf(
                   ViewStateRenderers.viewRenderer,
                   ViewStateRenderers.textViewRenderer(
                       includeTextViewText = true, textViewTextMaxLength = 4
@@ -64,12 +64,12 @@ class MainActivity : Activity() {
           )
         },
         "Custom LinearLayout renderer" to {
-          Radiography.scan(stateRenderers = defaultsNoPii + stateRendererFor<LinearLayout> {
+          Radiography.scan(viewStateRenderers = defaultsNoPii + viewStateRendererFor<LinearLayout> {
             append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
           })
         },
         "View.toString() renderer" to {
-          Radiography.scan(stateRenderers = listOf(stateRendererFor<View> {
+          Radiography.scan(viewStateRenderers = listOf(viewStateRendererFor<View> {
             append(
                 it.toString()
                     .substringAfter(' ')

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -16,6 +16,7 @@ import radiography.ViewFilter
 import radiography.ViewStateRenderers
 import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.ViewStateRenderers.DefaultsNoPii
+import radiography.and
 import radiography.scan
 import radiography.viewStateRendererFor
 

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -14,8 +14,8 @@ import radiography.Radiography
 import radiography.SkipIdsViewFilter
 import radiography.ViewFilter
 import radiography.ViewStateRenderers
-import radiography.ViewStateRenderers.defaultsIncludingPii
-import radiography.ViewStateRenderers.defaultsNoPii
+import radiography.ViewStateRenderers.DefaultsIncludingPii
+import radiography.ViewStateRenderers.DefaultsNoPii
 import radiography.scan
 import radiography.viewStateRendererFor
 
@@ -49,22 +49,22 @@ class MainActivity : Activity() {
         },
         "Include PII" to {
           Radiography.scan(
-              viewStateRenderers = defaultsIncludingPii
+              viewStateRenderers = DefaultsIncludingPii
           )
         },
         "Include PII ellipsized" to {
           Radiography.scan(
               viewStateRenderers = listOf(
-                  ViewStateRenderers.viewRenderer,
+                  ViewStateRenderers.ViewRenderer,
                   ViewStateRenderers.textViewRenderer(
                       includeTextViewText = true, textViewTextMaxLength = 4
                   ),
-                  ViewStateRenderers.checkableRenderer
+                  ViewStateRenderers.CheckableRenderer
               )
           )
         },
         "Custom LinearLayout renderer" to {
-          Radiography.scan(viewStateRenderers = defaultsNoPii + viewStateRendererFor<LinearLayout> {
+          Radiography.scan(viewStateRenderers = DefaultsNoPii + viewStateRendererFor<LinearLayout> {
             append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
           })
         },


### PR DESCRIPTION
* Make `ViewFilter.and` an extension function.
* Make `ViewStateRenderers` properties static and fix case.
* Generate JVM overloads for methods with default args.
* Rename StateRenderer to `ViewStateRenderer`.