### PR TITLE
Fix ViewFilters' behavior for non-View nodes.

### DIFF
--- a/radiography/src/main/java/radiography/FocusedWindowViewFilter.kt
+++ b/radiography/src/main/java/radiography/FocusedWindowViewFilter.kt
@@ -8,6 +8,6 @@ import android.view.View
 object FocusedWindowViewFilter : ViewFilter {
 
   override fun matches(view: Any): Boolean {
-    return view is View && (view.parent?.parent != null || view.hasWindowFocus())
+    return view !is View || (view.parent?.parent != null || view.hasWindowFocus())
   }
 }

--- a/radiography/src/main/java/radiography/SkipIdsViewFilter.kt
+++ b/radiography/src/main/java/radiography/SkipIdsViewFilter.kt
@@ -8,7 +8,7 @@ import android.view.View
 class SkipIdsViewFilter(private vararg val skippedIds: Int) : ViewFilter {
 
   override fun matches(view: Any): Boolean {
-    if (view !is View) return false
+    if (view !is View) return true
     val viewId = view.id
     return (viewId == View.NO_ID || skippedIds.isEmpty() || skippedIds.binarySearch(viewId) < 0)
   }

--- a/radiography/src/main/java/radiography/ViewFilter.kt
+++ b/radiography/src/main/java/radiography/ViewFilter.kt
@@ -21,7 +21,6 @@ interface ViewFilter {
 infix fun ViewFilter.and(otherFilter: ViewFilter): ViewFilter {
   val thisFilter = this
   return object : ViewFilter {
-    override fun matches(view: Any) = thisFilter.matches(view) &&
-        otherFilter.matches(view)
+    override fun matches(view: Any) = thisFilter.matches(view) && otherFilter.matches(view)
   }
 }


### PR DESCRIPTION
They should "match" non-`View` nodes, and only filter when the node is actually a `View`. This behavior is never exercised right now, but would cause any of the existing filters to filter out all compose nodes when compose support is added.