### PR TITLE
Enable Explicit API mode.

### DIFF
--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("com.android.library")
@@ -40,6 +41,18 @@ android {
 
   buildFeatures {
     buildConfig = false
+  }
+}
+
+tasks.withType<KotlinCompile> {
+  // Tests aren't part of the public API, don't turn explicit API mode on for them.
+  if (!name.contains("test", ignoreCase = true)) {
+    kotlinOptions {
+      // Require explicit public modifiers and types.
+      // TODO this should be moved to a top-level `kotlin { explicitApi() }` once that's working
+      //  for android projects, see https://youtrack.jetbrains.com/issue/KT-37652.
+      freeCompilerArgs = listOf("-Xexplicit-api=strict")
+    }
   }
 }
 

--- a/radiography/src/main/java/radiography/AttributeAppendable.kt
+++ b/radiography/src/main/java/radiography/AttributeAppendable.kt
@@ -1,12 +1,12 @@
 package radiography
 
-class AttributeAppendable(
+public class AttributeAppendable(
   private val stringBuilder: StringBuilder
 ) {
 
   private var first = true
 
-  fun append(attribute: CharSequence?) {
+  public fun append(attribute: CharSequence?) {
     if (attribute == null) {
       return
     }

--- a/radiography/src/main/java/radiography/FocusedWindowViewFilter.kt
+++ b/radiography/src/main/java/radiography/FocusedWindowViewFilter.kt
@@ -5,7 +5,7 @@ import android.view.View
 /**
  * Filters out root views that don't currently have the window focus from the output of [Radiography.scan].
  */
-object FocusedWindowViewFilter : ViewFilter {
+public object FocusedWindowViewFilter : ViewFilter {
 
   override fun matches(view: Any): Boolean {
     return view is View && (view.parent?.parent != null || view.hasWindowFocus())

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicReference
  * Utility class to scan through a view hierarchy and pretty print it to a [String].
  * Call [scan] or [View.scan].
  */
-object Radiography {
+public object Radiography {
 
   /**
    * Scans the view hierarchies and pretty print them to a [String].
@@ -38,7 +38,7 @@ object Radiography {
    */
   @JvmStatic
   @JvmOverloads
-  fun scan(
+  public fun scan(
     rootView: View? = null,
     viewStateRenderers: List<ViewStateRenderer<*>> = DefaultsNoPii,
     viewFilter: ViewFilter = ViewFilter.All

--- a/radiography/src/main/java/radiography/SkipIdsViewFilter.kt
+++ b/radiography/src/main/java/radiography/SkipIdsViewFilter.kt
@@ -5,7 +5,7 @@ import android.view.View
 /**
  * Filters out views with ids matching [skippedIds] from the output of [Radiography.scan].
  */
-class SkipIdsViewFilter(private vararg val skippedIds: Int) : ViewFilter {
+public class SkipIdsViewFilter(private vararg val skippedIds: Int) : ViewFilter {
 
   override fun matches(view: Any): Boolean {
     if (view !is View) return false

--- a/radiography/src/main/java/radiography/ViewFilter.kt
+++ b/radiography/src/main/java/radiography/ViewFilter.kt
@@ -4,21 +4,21 @@ package radiography
 /**
  * Used to filter out views from the output of [Radiography.scan].
  */
-interface ViewFilter {
+public interface ViewFilter {
   /**
    * @return true to keep the view in the output of [Radiography.scan], false to filter it out.
    */
-  fun matches(view: Any): Boolean
+  public fun matches(view: Any): Boolean
 
-  object All : ViewFilter {
-    override fun matches(view: Any) = true
+  public object All : ViewFilter {
+    override fun matches(view: Any): Boolean = true
   }
 }
 
 /**
  * Creates a new filter that combines this filter with [otherFilter]
  */
-infix fun ViewFilter.and(otherFilter: ViewFilter): ViewFilter {
+public infix fun ViewFilter.and(otherFilter: ViewFilter): ViewFilter {
   val thisFilter = this
   return object : ViewFilter {
     override fun matches(view: Any) = thisFilter.matches(view) &&

--- a/radiography/src/main/java/radiography/ViewStateRenderer.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderer.kt
@@ -9,12 +9,12 @@ package radiography
  *  }
  * ```
  */
-class ViewStateRenderer<in T> @PublishedApi internal constructor(
+public class ViewStateRenderer<in T> @PublishedApi internal constructor(
   private val renderedClass: Class<T>,
   private val renderer: AttributeAppendable.(T) -> Unit
 ) {
 
-  fun appendAttributes(
+  public fun appendAttributes(
     appendable: AttributeAppendable,
     rendered: Any
   ) {
@@ -27,5 +27,6 @@ class ViewStateRenderer<in T> @PublishedApi internal constructor(
   }
 }
 
-inline fun <reified T> viewStateRendererFor(noinline renderer: AttributeAppendable.(T) -> Unit) =
-  ViewStateRenderer(T::class.java, renderer)
+public inline fun <reified T> viewStateRendererFor(
+  noinline renderer: AttributeAppendable.(T) -> Unit
+): ViewStateRenderer<T> = ViewStateRenderer(T::class.java, renderer)

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -5,10 +5,10 @@ import android.view.View
 import android.widget.Checkable
 import android.widget.TextView
 
-object ViewStateRenderers {
+public object ViewStateRenderers {
 
   @JvmField
-  val ViewRenderer: ViewStateRenderer<View> = viewStateRendererFor { view ->
+  public val ViewRenderer: ViewStateRenderer<View> = viewStateRendererFor { view ->
     if (view.id != View.NO_ID && view.resources != null) {
       try {
         val resourceName = view.resources.getResourceEntryName(view.id)
@@ -39,21 +39,21 @@ object ViewStateRenderers {
   }
 
   @JvmField
-  val CheckableRenderer: ViewStateRenderer<Checkable> = viewStateRendererFor { checkable ->
+  public val CheckableRenderer: ViewStateRenderer<Checkable> = viewStateRendererFor { checkable ->
     if (checkable.isChecked) {
       append("checked")
     }
   }
 
   @JvmField
-  val DefaultsNoPii: List<ViewStateRenderer<*>> = listOf(
+  public val DefaultsNoPii: List<ViewStateRenderer<*>> = listOf(
       ViewRenderer,
       textViewRenderer(includeTextViewText = false, textViewTextMaxLength = 0),
       CheckableRenderer
   )
 
   @JvmField
-  val DefaultsIncludingPii: List<ViewStateRenderer<*>> = listOf(
+  public val DefaultsIncludingPii: List<ViewStateRenderer<*>> = listOf(
       ViewRenderer,
       textViewRenderer(includeTextViewText = true),
       CheckableRenderer
@@ -69,7 +69,7 @@ object ViewStateRenderers {
    */
   @JvmStatic
   @JvmOverloads
-  fun textViewRenderer(
+  public fun textViewRenderer(
     includeTextViewText: Boolean = false,
     textViewTextMaxLength: Int = Int.MAX_VALUE
   ): ViewStateRenderer<TextView> {

--- a/radiography/src/main/java/radiography/Views.kt
+++ b/radiography/src/main/java/radiography/Views.kt
@@ -8,7 +8,7 @@ import radiography.ViewStateRenderers.DefaultsNoPii
  * @see Radiography.scan
  */
 @JvmSynthetic
-fun View?.scan(
+public fun View?.scan(
   viewStateRenderers: List<ViewStateRenderer<*>> = DefaultsNoPii,
   viewFilter: ViewFilter = ViewFilter.All
 ): String {


### PR DESCRIPTION
This mode requires all public declarations to have explicit `public` modifiers, and for all public-facing types to be specified even if they could be inferred.