### PR TITLE
Add trailing commas to last items in default renderer lists.

### DIFF
--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -52,14 +52,14 @@ public object ViewStateRenderers {
   public val DefaultsNoPii: List<ViewStateRenderer> = listOf(
       ViewRenderer,
       textViewRenderer(includeTextViewText = false, textViewTextMaxLength = 0),
-      CheckableRenderer
+      CheckableRenderer,
   ) + ComposeLayoutRenderers.DefaultsNoPii
 
   @JvmField
   public val DefaultsIncludingPii: List<ViewStateRenderer> = listOf(
       ViewRenderer,
       textViewRenderer(includeTextViewText = true),
-      CheckableRenderer
+      CheckableRenderer,
   ) + ComposeLayoutRenderers.DefaultsIncludingPii
 
   /**


### PR DESCRIPTION
This makes it easier to reorder items, and gives a cleaner diff when items are added or removed in the future.