### PR TITLE
Restrict stdlib usage to 1.3.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
-println("Building with Kotlin version ${Versions.Kotlin}")
+println("Building with Kotlin compiler version ${Versions.KotlinCompiler}")
+println("Building with Kotlin stdlib version ${Versions.KotlinStdlib}")
 
 buildscript {
   repositories {
@@ -72,6 +73,8 @@ subprojects {
       }
 
       jvmTarget = "1.6"
+      // Required to avoid warnings about using older stdlib version.
+      apiVersion = "1.3"
     }
   }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,12 +1,15 @@
 object Versions {
-  val Kotlin = System.getProperty("square.kotlinVersion") ?: "1.4.0"
+  val KotlinCompiler = System.getProperty("square.kotlinVersion") ?: "1.4.0"
+
+  /** Use a lower version of the stdlib so the library can be consumed by lower kotlin versions. */
+  val KotlinStdlib = System.getProperty("square.kotlinStdlibVersion") ?: "1.3.72"
 }
 
 object Dependencies {
   object Build {
     const val Android = "com.android.tools.build:gradle:4.0.0"
     const val MavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.12.0"
-    val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin}"
+    val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KotlinCompiler}"
     const val Ktlint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
     const val BinaryCompatibility = "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.3"
   }

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -57,6 +57,8 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
+  implementation(kotlin("stdlib", Versions.KotlinStdlib))
+
   testImplementation(Dependencies.JUnit)
   testImplementation(Dependencies.Mockito)
   testImplementation(Dependencies.Robolectric)

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -78,16 +78,19 @@ public object Radiography {
 
     for (view in matchingRootViews) {
       if (length > 0) {
-        appendLine()
+        @Suppress("DEPRECATION")
+        appendln()
       }
       val layoutParams = view.layoutParams
       val title = (layoutParams as? WindowManager.LayoutParams)?.title?.toString()
           ?: view.javaClass.name
-      appendLine("$title:")
+      @Suppress("DEPRECATION")
+      appendln("$title:")
 
       val startPosition = length
       try {
-        appendLine("window-focus:${view.hasWindowFocus()}")
+        @Suppress("DEPRECATION")
+        appendln("window-focus:${view.hasWindowFocus()}")
         renderTreeString(view, viewVisitor)
       } catch (e: Throwable) {
         insert(

--- a/radiography/src/main/java/radiography/RenderTreeString.kt
+++ b/radiography/src/main/java/radiography/RenderTreeString.kt
@@ -71,7 +71,8 @@ private fun <N> StringBuilder.renderRecursively(
 
   nodeDescription.lineSequence().forEachIndexed { index, line ->
     appendLinePrefix(depth, continuePreviousLine = index > 0, lastChildMask = lastChildMask)
-    appendLine(line)
+    @Suppress("DEPRECATION")
+    appendln(line)
   }
 
   if (children.isEmpty()) return

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -35,5 +35,6 @@ android {
 }
 
 dependencies {
+  implementation(kotlin("stdlib", Versions.KotlinStdlib))
   implementation(project(":radiography"))
 }


### PR DESCRIPTION
This reverts the changes to stdlib call sites made in 0a0f4d266537f8bdc78fa94cc4f9166a790d2376.

This change ensures the library is still consumable from projects built with kotlin 1.3.

Some [discussion on Kotlin Slack](https://kotlinlang.slack.com/archives/C0922A726/p1597943810029800?thread_ts=1597937325.024100&cid=C0922A726) about this, using Kt 1.4 with `apiVersion = "1.3"` isn't enough, and using Kt 1.3 setting `languageLevel = "1.4"` won't work either. 