### PR TITLE
Revert kotlin 1.4 upgrade since it's easier than trying to explicitly support 1.3 consumers

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         kotlin-version:
+          - 1.3.72
           - 1.4.0
     runs-on: ubuntu-latest
     steps:

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object Versions {
-  val Kotlin = System.getProperty("square.kotlinVersion") ?: "1.4.0"
+  val Kotlin = System.getProperty("square.kotlinVersion") ?: "1.3.72"
 }
 
 object Dependencies {

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -44,6 +44,8 @@ android {
 }
 
 dependencies {
+  implementation(kotlin("stdlib"))
+
   testImplementation(Dependencies.JUnit)
   testImplementation(Dependencies.Mockito)
   testImplementation(Dependencies.Robolectric)

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("com.android.library")
@@ -41,18 +40,6 @@ android {
 
   buildFeatures {
     buildConfig = false
-  }
-}
-
-tasks.withType<KotlinCompile> {
-  // Tests aren't part of the public API, don't turn explicit API mode on for them.
-  if (!name.contains("test", ignoreCase = true)) {
-    kotlinOptions {
-      // Require explicit public modifiers and types.
-      // TODO this should be moved to a top-level `kotlin { explicitApi() }` once that's working
-      //  for android projects, see https://youtrack.jetbrains.com/issue/KT-37652.
-      freeCompilerArgs = listOf("-Xexplicit-api=strict")
-    }
   }
 }
 

--- a/radiography/src/main/java/radiography/AttributeAppendable.kt
+++ b/radiography/src/main/java/radiography/AttributeAppendable.kt
@@ -1,12 +1,12 @@
 package radiography
 
-public class AttributeAppendable(
+class AttributeAppendable(
   private val stringBuilder: StringBuilder
 ) {
 
   private var first = true
 
-  public fun append(attribute: CharSequence?) {
+  fun append(attribute: CharSequence?) {
     if (attribute == null) {
       return
     }

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicReference
  * Utility class to scan through a view hierarchy and pretty print it to a [String].
  * Call [scan] or [View.scan].
  */
-public object Radiography {
+object Radiography {
 
   /**
    * Scans the view hierarchies and pretty print them to a [String].
@@ -38,7 +38,7 @@ public object Radiography {
    */
   @JvmStatic
   @JvmOverloads
-  public fun scan(
+  fun scan(
     rootView: View? = null,
     viewStateRenderers: List<ViewStateRenderer> = DefaultsNoPii,
     viewFilter: ViewFilter = ViewFilters.NoFilter

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -78,16 +78,19 @@ object Radiography {
 
     for (view in matchingRootViews) {
       if (length > 0) {
-        appendLine()
+        @Suppress("DEPRECATION")
+        appendln()
       }
       val layoutParams = view.layoutParams
       val title = (layoutParams as? WindowManager.LayoutParams)?.title?.toString()
           ?: view.javaClass.name
-      appendLine("$title:")
+      @Suppress("DEPRECATION")
+      appendln("$title:")
 
       val startPosition = length
       try {
-        appendLine("window-focus:${view.hasWindowFocus()}")
+        @Suppress("DEPRECATION")
+        appendln("window-focus:${view.hasWindowFocus()}")
         renderTreeString(view, viewVisitor)
       } catch (e: Throwable) {
         insert(

--- a/radiography/src/main/java/radiography/RenderTreeString.kt
+++ b/radiography/src/main/java/radiography/RenderTreeString.kt
@@ -71,7 +71,8 @@ private fun <N> StringBuilder.renderRecursively(
 
   nodeDescription.lineSequence().forEachIndexed { index, line ->
     appendLinePrefix(depth, continuePreviousLine = index > 0, lastChildMask = lastChildMask)
-    appendLine(line)
+    @Suppress("DEPRECATION")
+    appendln(line)
   }
 
   if (children.isEmpty()) return

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -36,4 +36,5 @@ android {
 
 dependencies {
   implementation(project(":radiography"))
+  implementation(kotlin("stdlib"))
 }


### PR DESCRIPTION
See [this slack thread](https://kotlinlang.slack.com/archives/C0922A726/p1597943810029800?thread_ts=1597937325.024100&cid=C0922A726).

Replaces #50.