### PR TITLE
WIP Add support for only rendering certain sub-trees.

### DIFF
--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import android.view.View
 import android.view.WindowManager
 import radiography.Radiography.scan
+import radiography.ViewFilter.FilterResult.INCLUDE
 import radiography.ViewStateRenderers.DefaultsNoPii
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.SECONDS
@@ -73,7 +74,7 @@ public object Radiography {
       listOf(it)
     } ?: WindowScanner.findAllRootViews()
 
-    val matchingRootViews = rootViews.filter(viewFilter::matches)
+    val matchingRootViews = rootViews.filter { viewFilter.matches(it) == INCLUDE }
     val viewVisitor = ViewTreeRenderingVisitor(viewStateRenderers, viewFilter)
 
     for (view in matchingRootViews) {

--- a/radiography/src/main/java/radiography/ViewFilter.kt
+++ b/radiography/src/main/java/radiography/ViewFilter.kt
@@ -1,26 +1,44 @@
 package radiography
 
+import radiography.ViewFilter.FilterResult
+import radiography.ViewFilter.FilterResult.INCLUDE
+
 /**
  * Used to filter out views from the output of [Radiography.scan].
  */
+// TODO this isn't really just a "filter" anymore, it's more of a "selector". Rename?
 public interface ViewFilter {
+
+  enum class FilterResult {
+    /** Include this view and all of its children which also match the filter. */
+    INCLUDE,
+
+    /** Exclude this view, but include all of its children which match the filter. */
+    INCLUDE_ONLY_CHILDREN,
+
+    /** Exclude this view and don't process any of its children. */
+    EXCLUDE
+  }
+
   /**
    * @return true to keep the view in the output of [Radiography.scan], false to filter it out.
    */
-  public fun matches(view: Any): Boolean
+  public fun matches(view: Any): FilterResult
 }
 
 /**
  * Base class for implementations of [ViewFilter] that only want to filter instances of a specific
- * type. Instances of other types are always "matched" by this filter.
+ * type. Instances of other types are always [included][INCLUDE] by this filter.
  */
 internal abstract class TypedViewFilter<in T : Any>(
   private val filterClass: Class<T>
 ) : ViewFilter {
-  public abstract fun matchesTyped(view: T): Boolean
+  public abstract fun matchesTyped(view: T): FilterResult
 
-  final override fun matches(view: Any): Boolean {
+  final override fun matches(view: Any): FilterResult {
+    if (!filterClass.isInstance(view)) return INCLUDE
+
     @Suppress("UNCHECKED_CAST")
-    return !filterClass.isInstance(view) || matchesTyped(view as T)
+    return matchesTyped(view as T)
   }
 }

--- a/radiography/src/main/java/radiography/ViewFilters.kt
+++ b/radiography/src/main/java/radiography/ViewFilters.kt
@@ -1,13 +1,17 @@
 package radiography
 
 import android.view.View
+import radiography.ViewFilter.FilterResult
+import radiography.ViewFilter.FilterResult.EXCLUDE
+import radiography.ViewFilter.FilterResult.INCLUDE
+import radiography.ViewFilter.FilterResult.INCLUDE_ONLY_CHILDREN
 
 public object ViewFilters {
 
   /** A [ViewFilter] that matches everything (does not do any filtering). */
   @JvmStatic
   public val NoFilter: ViewFilter = object : ViewFilter {
-    override fun matches(view: Any): Boolean = true
+    override fun matches(view: Any) = INCLUDE
   }
 
   /**
@@ -16,7 +20,7 @@ public object ViewFilters {
    */
   @JvmField
   public val FocusedWindowViewFilter: ViewFilter = viewFilterFor<View> { view ->
-    view.parent?.parent != null || view.hasWindowFocus()
+    if (view.parent?.parent != null || view.hasWindowFocus()) INCLUDE else EXCLUDE
   }
 
   /**
@@ -25,39 +29,51 @@ public object ViewFilters {
   @JvmStatic
   public fun skipIdsViewFilter(vararg skippedIds: Int): ViewFilter = viewFilterFor<View> { view ->
     val viewId = view.id
-    (viewId == View.NO_ID || skippedIds.isEmpty() || skippedIds.binarySearch(viewId) < 0)
+    if (viewId == View.NO_ID ||
+        skippedIds.isEmpty() ||
+        skippedIds.binarySearch(viewId) < 0
+    ) INCLUDE else EXCLUDE
   }
 
   /**
    * Creates a new filter that combines this filter with [otherFilter]
    */
+  // TODO unit tests for all combinations of FilterResults.
   @JvmStatic
   public infix fun ViewFilter.and(otherFilter: ViewFilter): ViewFilter {
     val thisFilter = this
     return object : ViewFilter {
-      override fun matches(view: Any) = thisFilter.matches(view) && otherFilter.matches(view)
+      override fun matches(view: Any): FilterResult {
+        val thisResult = thisFilter.matches(view)
+        val otherResult = otherFilter.matches(view)
+
+        if (thisResult == EXCLUDE || otherResult == EXCLUDE) return EXCLUDE
+        if (thisResult == INCLUDE && otherResult == INCLUDE) return INCLUDE
+
+        // At least one filter wants to exclude this node, but both filters want to include
+        // children.
+        return INCLUDE_ONLY_CHILDREN
+      }
     }
   }
 
-  /**
-   * Returns a [ViewFilter] that matches any instances of [T] for which [predicate] returns true.
-   */
+  /** Returns a [ViewFilter] that matches instances of [T] using [matches]. */
   // This function is only visible to Kotlin consumers of this library.
-  public inline fun <reified T : Any> viewFilterFor(noinline predicate: (T) -> Boolean): ViewFilter {
+  public inline fun <reified T : Any> viewFilterFor(
+    noinline matches: (T) -> FilterResult
+  ): ViewFilter {
     // Don't create an anonymous instance here, since that would generate a new anonymous class at
     // every call site.
-    return viewFilterFor(T::class.java, predicate)
+    return viewFilterFor(T::class.java, matches)
   }
 
-  /**
-   * Returns a [ViewFilter] that matches any instances of [T] for which [predicate] returns true.
-   */
+  /** Returns a [ViewFilter] that matches instances of [T] using [matches]. */
   // This function is only visible to Java consumers of this library.
   @JvmStatic
   @PublishedApi internal fun <T : Any> viewFilterFor(
     filterClass: Class<T>,
-    predicate: (T) -> Boolean
+    matches: (T) -> FilterResult
   ): ViewFilter = object : TypedViewFilter<T>(filterClass) {
-    override fun matchesTyped(view: T): Boolean = predicate(view)
+    override fun matchesTyped(view: T) = matches(view)
   }
 }

--- a/radiography/src/main/java/radiography/compose/ComposeLayoutFilters.kt
+++ b/radiography/src/main/java/radiography/compose/ComposeLayoutFilters.kt
@@ -4,10 +4,35 @@ import androidx.compose.ui.layout.LayoutIdParentData
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties.TestTag
 import radiography.ViewFilter
+import radiography.ViewFilter.FilterResult.EXCLUDE
+import radiography.ViewFilter.FilterResult.INCLUDE
+import radiography.ViewFilter.FilterResult.INCLUDE_ONLY_CHILDREN
 import radiography.ViewFilters.viewFilterFor
 
 @ExperimentalRadiographyComposeApi
 object ComposeLayoutFilters {
+
+  /**
+   * TODO kdoc
+   */
+  // TODO tests
+  @ExperimentalRadiographyComposeApi
+  @JvmStatic
+  fun startFromTestTag(testTag: String): ViewFilter =
+    viewFilterFor<ComposeLayoutInfo> { layoutInfo ->
+      tailrec fun ComposeLayoutInfo.hasTestTag(): Boolean {
+        // TODO This is getting recomputed a lot, can we cache it directly in ComposeLayoutInfo?
+        if (testTag in testTags) return true
+        if (parent == null) return false
+        return parent.hasTestTag()
+      }
+
+      return@viewFilterFor if (layoutInfo.hasTestTag()) {
+        INCLUDE
+      } else {
+        INCLUDE_ONLY_CHILDREN
+      }
+    }
 
   /**
    * Filters out Composables with [`testTag`][androidx.compose.ui.platform.testTag] modifiers
@@ -17,14 +42,17 @@ object ComposeLayoutFilters {
   @JvmStatic
   fun skipTestTagsFilter(vararg skippedTestTags: String): ViewFilter =
     viewFilterFor<ComposeLayoutInfo> { layoutInfo ->
-      layoutInfo.modifiers.asSequence()
-          .filterIsInstance<SemanticsModifier>()
-          .flatMap { semantics ->
-            semantics.semanticsConfiguration.asSequence()
-                .filter { it.key == TestTag }
-          }
-          .none { it.value in skippedTestTags }
+      layoutInfo.testTags.none { it in skippedTestTags }
+          .let { if (it) INCLUDE else EXCLUDE }
     }
+
+  private val ComposeLayoutInfo.testTags: Sequence<String>
+    get() = modifiers.asSequence()
+        .filterIsInstance<SemanticsModifier>()
+        .flatMap { semantics ->
+          semantics.semanticsConfiguration.asSequence()
+        }
+        .mapNotNull { (key, value) -> (value as? String).takeIf { key == TestTag } }
 
   /**
    * Filters out Composables with [`layoutId`][androidx.compose.ui.layout.layoutId] modifiers for
@@ -37,5 +65,6 @@ object ComposeLayoutFilters {
       layoutInfo.modifiers.asSequence()
           .filterIsInstance<LayoutIdParentData>()
           .none { skipLayoutId(it.id) }
+          .let { if (it) INCLUDE else EXCLUDE }
     }
 }

--- a/radiography/src/main/java/radiography/compose/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/compose/ComposeViews.kt
@@ -82,9 +82,9 @@ internal fun tryVisitComposeView(
   if (!visited) {
     // Compose version is unsupported, include a warning but then continue rendering Android
     // views.
-    renderingScope.description.append("\n$COMPOSE_UNSUPPORTED_MESSAGE")
+    renderingScope.description?.append("\n$COMPOSE_UNSUPPORTED_MESSAGE")
     linkageError?.let {
-      renderingScope.description.append("\nError: $linkageError")
+      renderingScope.description?.append("\nError: $linkageError")
     }
   }
 

--- a/radiography/src/main/java/radiography/compose/LayoutInfoVisitor.kt
+++ b/radiography/src/main/java/radiography/compose/LayoutInfoVisitor.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.unit.IntBounds
 import radiography.AttributeAppendable
 import radiography.TreeRenderingVisitor
 import radiography.ViewFilter
+import radiography.ViewFilter.FilterResult.EXCLUDE
+import radiography.ViewFilter.FilterResult.INCLUDE
+import radiography.ViewFilter.FilterResult.INCLUDE_ONLY_CHILDREN
 import radiography.ViewStateRenderer
 import radiography.formatPixelDimensions
 
@@ -24,41 +27,52 @@ internal class LayoutInfoVisitor(
     } catch (e: LinkageError) {
       // The Compose code on the classpath is not what we expected – the app is probably using a
       // newer (or older) version of Compose than we support.
-      description.appendln(COMPOSE_UNSUPPORTED_MESSAGE)
-      description.append("Error: ${e.message}")
+      description?.appendln(COMPOSE_UNSUPPORTED_MESSAGE)
+      description?.append("Error: ${e.message}")
     }
   }
 
   private fun RenderingScope.visitNodeAssumingComposeSupported(node: ComposeLayoutInfo) {
-    with(description) {
-      append(node.name)
-
-      append(" { ")
-      val appendable = AttributeAppendable(description)
-      node.bounds.describeSize()?.let(appendable::append)
-
-      node.modifiers.forEach { modifier ->
-        modifierRenderers.forEach { renderer ->
-          with(renderer) {
-            appendable.render(modifier)
-          }
-        }
-      }
-      append(" }")
-    }
+    description?.layoutInfoToString(node)
 
     // Visit LayoutNode children. View nodes don't seem to have children, but they theoretically
     // could so try to visit them just in case.
     node.children
-        .filter(viewFilter::matches)
-        .forEach {
-          addChildToVisit(it)
+        .forEach { childInfo ->
+          when (viewFilter.matches(childInfo)) {
+            INCLUDE -> addChildToVisit(childInfo, this@LayoutInfoVisitor)
+            INCLUDE_ONLY_CHILDREN -> addChildToVisit(childInfo, this@LayoutInfoVisitor, skip = true)
+            EXCLUDE -> {
+              // Noop.
+            }
+          }
         }
 
     // This node was an emitted Android View, so trampoline back to the View renderer.
-    node.view?.takeIf(viewFilter::matches)?.let { view ->
-      addChildToVisit(view, classicViewVisitor)
+    when (node.view?.let(viewFilter::matches)) {
+      INCLUDE -> addChildToVisit(node.view, classicViewVisitor)
+      INCLUDE_ONLY_CHILDREN -> addChildToVisit(node.view, classicViewVisitor, skip = true)
+      else -> {
+        // Noop.
+      }
     }
+  }
+
+  private fun StringBuilder.layoutInfoToString(node: ComposeLayoutInfo) {
+    append(node.name)
+
+    append(" { ")
+    val appendable = AttributeAppendable(this)
+    node.bounds.describeSize()?.let(appendable::append)
+
+    node.modifiers.forEach { modifier ->
+      modifierRenderers.forEach { renderer ->
+        with(renderer) {
+          appendable.render(modifier)
+        }
+      }
+    }
+    append(" }")
   }
 }
 


### PR DESCRIPTION
This change allows filters to be written which not only exclude certain subtrees, but also which _only_ include certain subtrees. 

It has three parts:
1. Change `ViewFilter`'s matches method to return a three-value type instead of a boolean, where the third value means don't include this view, but include its children.
2. Give `ComposeLayoutInfo` a pointer to its parent. 
3. Write a filter for compose that returns "include only children" for all nodes that don't have a parent which matches a certain test tag. 

**Open questions**
- [ ] Is the new ViewFilter API acceptable?
- [ ] Should `viewFilterFor` still accept a boolean lambda instead of all 3 values, since the third value is likely not needed by most filters and it would allow more readable single-expression filters.
- [ ] Is searching up the tree on every node an acceptable cost?
- [ ] This approach requires the filter to be aware of _all_ types that are visitable - a composable nested in an Android view nested inside a composable would also need to walk up the inner `View` hierarchy so that it included the complete subtrees. Would a better approach to make the filter stateful, so it could set an internal flag while visiting children that match? This would also be more efficient, since it wouldn't need to walk up the parent chain for every node. However it requires a slightly bigger change to the filter API.

One way to solve the last point would be to pass an arbitrary value down the filter chain:
```kotlin
fun interface ViewFilter<S> {
  fun matches(view: Any, filterState: S): Pair<FilterResult, S>
}

fun startFromTestTag(testTag: String): ViewFilter =
  viewFilterFor<ComposeLayoutInfo> { layoutInfo, alreadyMatched ->
    if (alreadyMatched || (testTag in testTags)) {
      Pair(INCLUDE, true)
    } else {
      Pair(INCLUDE_ONLY_CHILDREN, false)
    }
  }
```
We could also then provide two versions of `viewFilterFor`, a simple one (no filter state, boolean return) and a complete one (same signature as the above method). One issue with this is that the returned filter state value would be ignored if the result is `EXCLUDE`, so a sealed class might be better for the result than an enum at that point:
```kotlin
sealed class FilterResult<out S> {
  class Include<S>(val filterState: S) : FilterResult<S>()
  class IncludeOnlyChildren<S>(val filterState: S) : FilterResult<S>()
  object Exclude : FilterResult<Nothing>()
}
```

Fixes #58.