### PR TITLE
Use a sealed class to distinguish between Android and Compose in ViewStateRenderer and ViewFilter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ val prettyHierarchy = Radiography.scan(viewStateRenderers = DefaultsIncludingPii
 
 // Append custom attribute rendering
 val prettyHierarchy = Radiography.scan(viewStateRenderers = DefaultsNoPii +
-    viewStateRendererFor<LinearLayout> {
+    androidViewStateRendererFor<LinearLayout> {
       append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
     })
 ```
@@ -184,7 +184,7 @@ Button { id:show_dialog, 652x126px, text-length:28 }
 If you'd rather rely on `View.toString()`, you can provide a custom state renderer.
 
 ```kotlin
-val prettyHierarchy = Radiography.scan(viewStateRenderers = listOf(viewStateRendererFor<View> {
+val prettyHierarchy = Radiography.scan(viewStateRenderers = listOf(androidViewStateRendererFor<View> {
   append(
       it.toString()
           .substringAfter(' ')

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Stack
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
+import androidx.compose.material.TextField
 import androidx.compose.runtime.SlotTable
 import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.Modifier
@@ -140,7 +141,7 @@ class ComposeUiTest {
     assertThat(hierarchy).contains("Checked")
   }
 
-  @Test fun textViewContents() {
+  @Test fun textContents() {
     composeRule.setContent {
       Text("Baguette Avec Fromage")
     }
@@ -153,9 +154,42 @@ class ComposeUiTest {
     assertThat(hierarchy).contains("text:\"Baguette Avec Fromage\"")
   }
 
-  @Test fun textViewContentsEllipsized() {
+  @Test fun textContentsEllipsized() {
     composeRule.setContent {
       Text("Baguette Avec Fromage")
+    }
+
+    val hierarchy = runOnIdle {
+      Radiography.scan(
+          viewStateRenderers = listOf(
+              composeTextRenderer(
+                  includeText = true,
+                  maxTextLength = 11
+              )
+          )
+      )
+    }
+
+    assertThat(hierarchy).contains("text-length:21")
+    assertThat(hierarchy).contains("text:\"Baguette A…\"")
+  }
+
+  @Test fun textFieldContents() {
+    composeRule.setContent {
+      TextField("Baguette Avec Fromage", onValueChange = {}, label = {})
+    }
+
+    val hierarchy = runOnIdle {
+      Radiography.scan(viewStateRenderers = listOf(composeTextRenderer(includeText = true)))
+    }
+
+    assertThat(hierarchy).contains("text-length:21")
+    assertThat(hierarchy).contains("text:\"Baguette Avec Fromage\"")
+  }
+
+  @Test fun textFieldContentsEllipsized() {
+    composeRule.setContent {
+      TextField("Baguette Avec Fromage", onValueChange = {}, label = {})
     }
 
     val hierarchy = runOnIdle {

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -38,7 +38,7 @@ import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.ViewStateRenderers.DefaultsNoPii
 import radiography.compose.ComposeLayoutFilters.skipLayoutIdsFilter
 import radiography.compose.ComposeLayoutFilters.skipTestTagsFilter
-import radiography.compose.ComposeLayoutRenderers.StandardSemanticsRenderer
+import radiography.compose.ComposeLayoutRenderers.ComposeViewRenderer
 import radiography.compose.ComposeLayoutRenderers.composeTextRenderer
 import radiography.compose.ExperimentalRadiographyComposeApi
 import radiography.compose.scan
@@ -82,7 +82,7 @@ class ComposeUiTest {
     }
 
     val hierarchy = runOnIdle {
-      Radiography.scan(viewStateRenderers = emptyList())
+      Radiography.scan(viewStateRenderers = listOf(ComposeViewRenderer))
     }
 
     assertThat(hierarchy).contains("Box { 30×40px }")
@@ -134,7 +134,7 @@ class ComposeUiTest {
     }
 
     val hierarchy = runOnIdle {
-      Radiography.scan(viewStateRenderers = listOf(StandardSemanticsRenderer))
+      Radiography.scan(viewStateRenderers = listOf(ComposeViewRenderer))
     }
 
     assertThat(hierarchy).contains("Checkbox")

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -21,8 +21,10 @@ public final class radiography/ScannableView$AndroidView : radiography/Scannable
 }
 
 public final class radiography/ScannableView$ComposeView : radiography/ScannableView {
-	public fun <init> (Ljava/util/List;)V
+	public fun <init> (IILjava/util/List;)V
+	public final fun getHeight ()I
 	public final fun getModifiers ()Ljava/util/List;
+	public final fun getWidth ()I
 }
 
 public abstract interface class radiography/ViewFilter {
@@ -67,11 +69,11 @@ public final class radiography/compose/ComposeLayoutFilters {
 }
 
 public final class radiography/compose/ComposeLayoutRenderers {
+	public static final field ComposeViewRenderer Lradiography/ViewStateRenderer;
 	public static final field DefaultsIncludingPii Ljava/util/List;
 	public static final field DefaultsNoPii Ljava/util/List;
 	public static final field INSTANCE Lradiography/compose/ComposeLayoutRenderers;
 	public static final field LayoutIdRenderer Lradiography/ViewStateRenderer;
-	public static final field StandardSemanticsRenderer Lradiography/ViewStateRenderer;
 	public static final fun composeTextRenderer ()Lradiography/ViewStateRenderer;
 	public static final fun composeTextRenderer (Z)Lradiography/ViewStateRenderer;
 	public static final fun composeTextRenderer (ZI)Lradiography/ViewStateRenderer;

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -12,21 +12,34 @@ public final class radiography/Radiography {
 	public static synthetic fun scan$default (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;ILjava/lang/Object;)Ljava/lang/String;
 }
 
+public abstract class radiography/ScannableView {
+}
+
+public final class radiography/ScannableView$AndroidView : radiography/ScannableView {
+	public fun <init> (Landroid/view/View;)V
+	public final fun getView ()Landroid/view/View;
+}
+
+public final class radiography/ScannableView$ComposeView : radiography/ScannableView {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getModifiers ()Ljava/util/List;
+}
+
 public abstract interface class radiography/ViewFilter {
-	public abstract fun matches (Ljava/lang/Object;)Z
+	public abstract fun matches (Lradiography/ScannableView;)Z
 }
 
 public final class radiography/ViewFilters {
 	public static final field FocusedWindowViewFilter Lradiography/ViewFilter;
 	public static final field INSTANCE Lradiography/ViewFilters;
 	public static final fun and (Lradiography/ViewFilter;Lradiography/ViewFilter;)Lradiography/ViewFilter;
+	public static final fun androidViewFilterFor (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lradiography/ViewFilter;
 	public static final fun getNoFilter ()Lradiography/ViewFilter;
 	public static final fun skipIdsViewFilter ([I)Lradiography/ViewFilter;
-	public static final fun viewFilterFor (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lradiography/ViewFilter;
 }
 
 public abstract interface class radiography/ViewStateRenderer {
-	public abstract fun render (Lradiography/AttributeAppendable;Ljava/lang/Object;)V
+	public abstract fun render (Lradiography/AttributeAppendable;Lradiography/ScannableView;)V
 }
 
 public final class radiography/ViewStateRenderers {
@@ -35,11 +48,11 @@ public final class radiography/ViewStateRenderers {
 	public static final field DefaultsNoPii Ljava/util/List;
 	public static final field INSTANCE Lradiography/ViewStateRenderers;
 	public static final field ViewRenderer Lradiography/ViewStateRenderer;
+	public static final fun androidViewStateRendererFor (Ljava/lang/Class;Lkotlin/jvm/functions/Function2;)Lradiography/ViewStateRenderer;
 	public static final fun textViewRenderer ()Lradiography/ViewStateRenderer;
 	public static final fun textViewRenderer (Z)Lradiography/ViewStateRenderer;
 	public static final fun textViewRenderer (ZI)Lradiography/ViewStateRenderer;
 	public static synthetic fun textViewRenderer$default (ZIILjava/lang/Object;)Lradiography/ViewStateRenderer;
-	public static final fun viewStateRendererFor (Ljava/lang/Class;Lkotlin/jvm/functions/Function2;)Lradiography/ViewStateRenderer;
 }
 
 public final class radiography/ViewsKt {

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import android.view.View
 import android.view.WindowManager
 import radiography.Radiography.scan
+import radiography.ScannableView.AndroidView
 import radiography.ViewStateRenderers.DefaultsNoPii
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.SECONDS
@@ -73,10 +74,11 @@ public object Radiography {
       listOf(it)
     } ?: WindowScanner.findAllRootViews()
 
-    val matchingRootViews = rootViews.filter(viewFilter::matches)
+    val matchingRootViews = rootViews.map(::AndroidView).filter(viewFilter::matches)
     val viewVisitor = ViewTreeRenderingVisitor(viewStateRenderers, viewFilter)
 
-    for (view in matchingRootViews) {
+    for (scannableView in matchingRootViews) {
+      val view = scannableView.view
       if (length > 0) {
         @Suppress("DEPRECATION")
         appendln()

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -1,0 +1,26 @@
+package radiography
+
+import android.view.View
+import androidx.compose.ui.Modifier
+import radiography.ScannableView.AndroidView
+import radiography.ScannableView.ComposeView
+import radiography.compose.ExperimentalRadiographyComposeApi
+
+/**
+ * Represents a logic view that can be rendered as a node in the view tree.
+ *
+ * Can either be an actual Android [View] ([AndroidView]) or a grouping of Composables that roughly
+ * represents the concept of a logical "view" ([ComposeView]).
+ */
+public sealed class ScannableView {
+
+  public class AndroidView(val view: View) : ScannableView()
+
+  /**
+   * Represents a group of Composables that make up a logical "view".
+   *
+   * @param modifiers The list of [Modifier]s that are currently applied to the Composable.
+   */
+  @ExperimentalRadiographyComposeApi
+  public class ComposeView(val modifiers: List<Modifier>) : ScannableView()
+}

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -2,6 +2,7 @@ package radiography
 
 import android.view.View
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntSize
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
 import radiography.compose.ExperimentalRadiographyComposeApi
@@ -22,5 +23,15 @@ public sealed class ScannableView {
    * @param modifiers The list of [Modifier]s that are currently applied to the Composable.
    */
   @ExperimentalRadiographyComposeApi
-  public class ComposeView(val modifiers: List<Modifier>) : ScannableView()
+  public class ComposeView(
+    val width: Int,
+    val height: Int,
+    val modifiers: List<Modifier>
+  ) : ScannableView() {
+
+    internal constructor(
+      size: IntSize,
+      modifiers: List<Modifier>
+    ) : this(size.width, size.height, modifiers)
+  }
 }

--- a/radiography/src/main/java/radiography/ViewFilter.kt
+++ b/radiography/src/main/java/radiography/ViewFilter.kt
@@ -7,20 +7,5 @@ public fun interface ViewFilter {
   /**
    * @return true to keep the view in the output of [Radiography.scan], false to filter it out.
    */
-  public fun matches(view: Any): Boolean
-}
-
-/**
- * Base class for implementations of [ViewFilter] that only want to filter instances of a specific
- * type. Instances of other types are always "matched" by this filter.
- */
-internal abstract class TypedViewFilter<in T : Any>(
-  private val filterClass: Class<T>
-) : ViewFilter {
-  public abstract fun matchesTyped(view: T): Boolean
-
-  final override fun matches(view: Any): Boolean {
-    @Suppress("UNCHECKED_CAST")
-    return !filterClass.isInstance(view) || matchesTyped(view as T)
-  }
+  public fun matches(view: ScannableView): Boolean
 }

--- a/radiography/src/main/java/radiography/ViewStateRenderer.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderer.kt
@@ -1,33 +1,16 @@
 package radiography
 
-import radiography.ViewStateRenderers.viewStateRendererFor
-
 /**
  * Renders extra attributes for specifics types in the output of [Radiography.scan].
- * Call [viewStateRendererFor] to create instances with reified types:
+ *
+ * Call [androidViewStateRendererFor][ViewStateRenderers.androidViewStateRendererFor] to create
+ * instances for specific [View][android.view.View] types:
  * ```
- *  val myRenderer: StateRenderer<MyView> = viewStateRendererFor {
+ *  val myRenderer: StateRenderer<MyView> = androidViewStateRendererFor {
  *    append(it.customAttributeValue)
  *  }
  * ```
  */
 public fun interface ViewStateRenderer {
-  public fun AttributeAppendable.render(rendered: Any)
-}
-
-/**
- * Base class for implementations of [ViewStateRenderer] that only want to render instances of a
- * specific type. Instances of other types are ignored.
- */
-internal abstract class TypedViewStateRenderer<in T : Any>(
-  private val renderClass: Class<T>
-) : ViewStateRenderer {
-  public abstract fun AttributeAppendable.renderTyped(rendered: T)
-
-  final override fun AttributeAppendable.render(rendered: Any) {
-    if (renderClass.isInstance(rendered)) {
-      @Suppress("UNCHECKED_CAST")
-      renderTyped(rendered as T)
-    }
-  }
+  public fun AttributeAppendable.render(view: ScannableView)
 }

--- a/radiography/src/main/java/radiography/ViewTreeRenderingVisitor.kt
+++ b/radiography/src/main/java/radiography/ViewTreeRenderingVisitor.kt
@@ -4,6 +4,7 @@ import android.annotation.TargetApi
 import android.os.Build.VERSION_CODES
 import android.view.View
 import android.view.ViewGroup
+import radiography.ScannableView.AndroidView
 import radiography.compose.tryVisitComposeView
 
 /**
@@ -16,7 +17,7 @@ internal class ViewTreeRenderingVisitor(
 ) : TreeRenderingVisitor<View>() {
 
   override fun RenderingScope.visitNode(node: View) {
-    description.viewToString(node)
+    description.viewToString(AndroidView(node))
 
     val isComposeView = tryVisitComposeView(
         this, node, viewStateRenderers, viewFilter, this@ViewTreeRenderingVisitor
@@ -34,19 +35,19 @@ internal class ViewTreeRenderingVisitor(
       // Child may be null, if children were removed by another thread after we captured the child
       // count. getChildAt returns null for invalid indices, it doesn't throw.
       val child = node.getChildAt(index) ?: continue
-      if (viewFilter.matches(child)) {
+      if (viewFilter.matches(AndroidView(child))) {
         addChildToVisit(child)
       }
     }
   }
 
   @TargetApi(VERSION_CODES.CUPCAKE)
-  private fun StringBuilder.viewToString(view: View) {
-    append("${view.javaClass.simpleName} { ")
+  private fun StringBuilder.viewToString(androidView: AndroidView) {
+    append("${androidView.view.javaClass.simpleName} { ")
     val appendable = AttributeAppendable(this)
     for (renderer in viewStateRenderers) {
       with(renderer) {
-        appendable.render(view)
+        appendable.render(androidView)
       }
     }
     append(" }")

--- a/radiography/src/main/java/radiography/compose/ComposeLayoutFilters.kt
+++ b/radiography/src/main/java/radiography/compose/ComposeLayoutFilters.kt
@@ -3,8 +3,8 @@ package radiography.compose
 import androidx.compose.ui.layout.LayoutIdParentData
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties.TestTag
+import radiography.ScannableView.ComposeView
 import radiography.ViewFilter
-import radiography.ViewFilters.viewFilterFor
 
 @ExperimentalRadiographyComposeApi
 object ComposeLayoutFilters {
@@ -15,16 +15,18 @@ object ComposeLayoutFilters {
    */
   @ExperimentalRadiographyComposeApi
   @JvmStatic
-  fun skipTestTagsFilter(vararg skippedTestTags: String): ViewFilter =
-    viewFilterFor<ComposeLayoutInfo> { layoutInfo ->
-      layoutInfo.modifiers.asSequence()
-          .filterIsInstance<SemanticsModifier>()
-          .flatMap { semantics ->
-            semantics.semanticsConfiguration.asSequence()
-                .filter { it.key == TestTag }
-          }
-          .none { it.value in skippedTestTags }
-    }
+  fun skipTestTagsFilter(vararg skippedTestTags: String): ViewFilter = ViewFilter {
+    (it as? ComposeView)
+        ?.modifiers
+        ?.asSequence()
+        ?.filterIsInstance<SemanticsModifier>()
+        ?.flatMap { semantics ->
+          semantics.semanticsConfiguration.asSequence()
+              .filter { it.key == TestTag }
+        }
+        ?.none { it.value in skippedTestTags }
+        ?: true
+  }
 
   /**
    * Filters out Composables with [`layoutId`][androidx.compose.ui.layout.layoutId] modifiers for
@@ -32,10 +34,12 @@ object ComposeLayoutFilters {
    */
   @ExperimentalRadiographyComposeApi
   @JvmStatic
-  fun skipLayoutIdsFilter(skipLayoutId: (Any) -> Boolean): ViewFilter =
-    viewFilterFor<ComposeLayoutInfo> { layoutInfo ->
-      layoutInfo.modifiers.asSequence()
-          .filterIsInstance<LayoutIdParentData>()
-          .none { skipLayoutId(it.id) }
-    }
+  fun skipLayoutIdsFilter(skipLayoutId: (Any) -> Boolean): ViewFilter = ViewFilter {
+    (it as? ComposeView)
+        ?.modifiers
+        ?.asSequence()
+        ?.filterIsInstance<LayoutIdParentData>()
+        ?.none { layoutId -> skipLayoutId(layoutId.id) }
+        ?: true
+  }
 }

--- a/radiography/src/main/java/radiography/compose/LayoutInfoVisitor.kt
+++ b/radiography/src/main/java/radiography/compose/LayoutInfoVisitor.kt
@@ -1,14 +1,13 @@
 package radiography.compose
 
 import android.view.View
-import androidx.compose.ui.unit.IntBounds
+import androidx.compose.ui.unit.toSize
 import radiography.AttributeAppendable
-import radiography.TreeRenderingVisitor
-import radiography.ViewFilter
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
+import radiography.TreeRenderingVisitor
+import radiography.ViewFilter
 import radiography.ViewStateRenderer
-import radiography.formatPixelDimensions
 
 /**
  * A [TreeRenderingVisitor] that recursively renders a tree of [ComposeLayoutInfo]s. It is the
@@ -38,9 +37,7 @@ internal class LayoutInfoVisitor(
 
       append(" { ")
       val appendable = AttributeAppendable(description)
-      node.bounds.describeSize()?.let(appendable::append)
-
-      val composeView = ComposeView(node.modifiers)
+      val composeView = ComposeView(node.bounds.toSize(), node.modifiers)
       modifierRenderers.forEach { renderer ->
         with(renderer) {
           appendable.render(composeView)
@@ -52,7 +49,7 @@ internal class LayoutInfoVisitor(
     // Visit LayoutNode children. View nodes don't seem to have children, but they theoretically
     // could so try to visit them just in case.
     node.children
-        .filter { viewFilter.matches(ComposeView(it.modifiers)) }
+        .filter { viewFilter.matches(ComposeView(it.bounds.toSize(), it.modifiers)) }
         .forEach {
           addChildToVisit(it)
         }
@@ -61,13 +58,5 @@ internal class LayoutInfoVisitor(
     node.view?.takeIf { viewFilter.matches(AndroidView(it)) }?.let { view ->
       addChildToVisit(view, classicViewVisitor)
     }
-  }
-}
-
-private fun IntBounds.describeSize(): String? {
-  return if (left != right || top != bottom) {
-    formatPixelDimensions(width = right - left, height = bottom - top)
-  } else {
-    null
   }
 }

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
@@ -50,8 +50,8 @@ import radiography.ViewStateRenderers.CheckableRenderer
 import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.ViewStateRenderers.DefaultsNoPii
 import radiography.ViewStateRenderers.ViewRenderer
+import radiography.ViewStateRenderers.androidViewStateRendererFor
 import radiography.ViewStateRenderers.textViewRenderer
-import radiography.ViewStateRenderers.viewStateRendererFor
 import radiography.compose.ComposeLayoutFilters.skipTestTagsFilter
 import radiography.compose.ComposeLayoutRenderers.LayoutIdRenderer
 import radiography.compose.ComposeLayoutRenderers.StandardSemanticsRenderer
@@ -146,8 +146,8 @@ private fun showSelectionDialog(context: Context) {
         Radiography.scan(viewFilter = skipTestTagsFilter(TEXT_FIELD_TEST_TAG))
       },
       "Focused window and custom filter" to {
-        Radiography.scan(viewFilter = FocusedWindowViewFilter and object : ViewFilter {
-          override fun matches(view: Any): Boolean = view !is LinearLayout
+        Radiography.scan(viewFilter = FocusedWindowViewFilter and ViewFilter { view ->
+          view !is LinearLayout
         })
       },
       "Include PII" to {
@@ -167,7 +167,7 @@ private fun showSelectionDialog(context: Context) {
       },
       "Custom LinearLayout renderer" to {
         Radiography.scan(
-            viewStateRenderers = DefaultsNoPii + viewStateRendererFor<LinearLayout> {
+            viewStateRenderers = DefaultsNoPii + androidViewStateRendererFor<LinearLayout> {
               append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
             })
       }

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
@@ -54,7 +54,7 @@ import radiography.ViewStateRenderers.androidViewStateRendererFor
 import radiography.ViewStateRenderers.textViewRenderer
 import radiography.compose.ComposeLayoutFilters.skipTestTagsFilter
 import radiography.compose.ComposeLayoutRenderers.LayoutIdRenderer
-import radiography.compose.ComposeLayoutRenderers.StandardSemanticsRenderer
+import radiography.compose.ComposeLayoutRenderers.ComposeViewRenderer
 import radiography.compose.ComposeLayoutRenderers.composeTextRenderer
 import radiography.compose.ExperimentalRadiographyComposeApi
 
@@ -160,7 +160,7 @@ private fun showSelectionDialog(context: Context) {
                 textViewRenderer(includeTextViewText = true, textViewTextMaxLength = 4),
                 CheckableRenderer,
                 LayoutIdRenderer,
-                StandardSemanticsRenderer,
+                ComposeViewRenderer,
                 composeTextRenderer(includeText = true, maxTextLength = 4)
             )
         )

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -17,7 +17,7 @@ import radiography.ViewFilters.skipIdsViewFilter
 import radiography.ViewStateRenderers
 import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.ViewStateRenderers.DefaultsNoPii
-import radiography.ViewStateRenderers.viewStateRendererFor
+import radiography.ViewStateRenderers.androidViewStateRendererFor
 import radiography.scan
 
 class MainActivity : Activity() {
@@ -64,12 +64,13 @@ class MainActivity : Activity() {
           )
         },
         "Custom LinearLayout renderer" to {
-          Radiography.scan(viewStateRenderers = DefaultsNoPii + viewStateRendererFor<LinearLayout> {
-            append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
-          })
+          Radiography.scan(
+              viewStateRenderers = DefaultsNoPii + androidViewStateRendererFor<LinearLayout> {
+                append(if (it.orientation == LinearLayout.HORIZONTAL) "horizontal" else "vertical")
+              })
         },
         "View.toString() renderer" to {
-          Radiography.scan(viewStateRenderers = listOf(viewStateRendererFor<View> {
+          Radiography.scan(viewStateRenderers = listOf(androidViewStateRendererFor<View> {
             append(
                 it.toString()
                     .substringAfter(' ')


### PR DESCRIPTION
Android-related logic is written in terms of `View`, Compose-related logic is written
in terms of `List<Modifier>`. This enables writing actual filters/renderers for Compose,
while exposing as little as possible about how Compose structures things internally.