### PR TITLE
Add links and samples to documentation about test tags.

### DIFF
--- a/radiography/src/main/java/radiography/ScanScopes.kt
+++ b/radiography/src/main/java/radiography/ScanScopes.kt
@@ -35,8 +35,26 @@ object ScanScopes {
   }
 
   /**
-   * Scans all Composables in all windows that have the `Modifier.testTag` modifier with the given
-   * [testTag].
+   * Limits the scope of the scan to start from composables that have a
+   * [`Modifier.testTag`][androidx.compose.ui.platform.testTag] modifier with the given [testTag].
+   * [All windows][AllWindowsScope] are searched by default, but you can limit where composables are
+   * found by passing another [ScanScope] to [inScope].
+   *
+   * Example:
+   * ```
+   * @Composable fun App() {
+   *   Column {
+   *     ActionBar()
+   *     Body(Modifier.testTag("app-body"))
+   *     BottomBar()
+   *   }
+   * }
+   *
+   * Radiography.scan(scanScope = composeTestTagScope("app-body"))
+   * ```
+   *
+   * To use test tags to filter out certain parts of your UI, use
+   * [radiography.compose.ComposableFilters.skipTestTagsFilter].
    */
   @ExperimentalRadiographyComposeApi
   @JvmStatic

--- a/radiography/src/main/java/radiography/ViewFilters.kt
+++ b/radiography/src/main/java/radiography/ViewFilters.kt
@@ -23,8 +23,24 @@ public object ViewFilters {
     }
 
   /**
-   * Filters out Composables with [`testTag`][androidx.compose.ui.platform.testTag] modifiers
-   * matching [skippedTestTags].
+   * Filters out composables with [`Modifier.testTag`][androidx.compose.ui.platform.testTag]
+   * modifiers matching [skippedTestTags].
+   *
+   * Example:
+   * ```
+   * @Composable fun App() {
+   *   ModalDrawerLayout(drawerContent = {
+   *     DebugDrawer(Modifier.testTag("debug-drawer"))
+   *   }) {
+   *     Scaffold(…)
+   *   }
+   * }
+   *
+   * Radiography.scan(viewFilter = skipComposeTestTagsFilter("debug-drawer"))
+   * ```
+   *
+   * To use test tags to limit the part of your UI that Radiography scans, use
+   * [radiography.ScanScopes.composeTestTagScope].
    */
   @ExperimentalRadiographyComposeApi
   @JvmStatic


### PR DESCRIPTION
Also fleshes out a lot more Compose documentation in the README, as well
as more general information about `ScanScope`.

Fixes #72.