### PR TITLE
Increase timeout for running UI tests in CI.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,7 +26,7 @@ jobs:
   instrumentation-tests:
     name: Instrumentation tests
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false


### PR DESCRIPTION
From 20 -> 30 minutes. Many runs have at least one shard that times out in 20 mins.