### PR TITLE
Update Compose to latest version.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,12 +8,7 @@ object Versions {
   /** Use a lower version of the stdlib so the library can be consumed by lower kotlin versions. */
   val KotlinStdlib = System.getProperty("square.kotlinStdlibVersion") ?: "1.3.72"
 
-  const val Compose = "1.0.0-alpha01"
-
-  // Allows using a different version of Compose to validate that we degrade gracefully on apps
-  // built with unsupported Compose versions.
-  const val OldCompose = "0.1.0-dev12"
-  const val OldComposeCompiler = "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
+  const val Compose = "1.0.0-alpha02"
 }
 
 object Dependencies {
@@ -32,12 +27,10 @@ object Dependencies {
   const val Robolectric = "org.robolectric:robolectric:4.3.1"
   const val Truth = "com.google.truth:truth:1.0.1"
 
-  object Compose {
-    const val Material = "androidx.compose.material:material:${Versions.Compose}"
-    const val Testing = "androidx.ui:ui-test:${Versions.Compose}"
-    const val OldMaterial = "androidx.ui:ui-material:${Versions.OldCompose}"
-    const val OldTesting = "androidx.ui:ui-test:${Versions.OldCompose}"
-    const val Tooling = "androidx.ui:ui-tooling:${Versions.Compose}"
+  class Compose(composeVersion: String = Versions.Compose) {
+    val Material = "androidx.compose.material:material:${composeVersion}"
+    val Testing = "androidx.ui:ui-test:${composeVersion}"
+    val Tooling = "androidx.ui:ui-tooling:${composeVersion}"
   }
 
   object InstrumentationTests {

--- a/compose-tests/build.gradle.kts
+++ b/compose-tests/build.gradle.kts
@@ -49,9 +49,9 @@ dependencies {
 
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
-  androidTestImplementation(Dependencies.Compose.Material)
-  androidTestImplementation(Dependencies.Compose.Testing)
-  androidTestImplementation(Dependencies.Compose.Tooling)
+  androidTestImplementation(Dependencies.Compose().Material)
+  androidTestImplementation(Dependencies.Compose().Testing)
+  androidTestImplementation(Dependencies.Compose().Tooling)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)
   androidTestImplementation(Dependencies.InstrumentationTests.Runner)
   androidTestImplementation(Dependencies.Truth)

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -5,6 +5,13 @@ plugins {
   kotlin("android")
 }
 
+/**
+ * Allows using a different version of Compose to validate that we degrade gracefully on apps
+ * built with unsupported Compose versions.
+ */
+val oldComposeVersion = "0.1.0-dev12"
+val oldComposeCompiler = "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
+
 android {
   compileSdkVersion(30)
 
@@ -27,8 +34,8 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerVersion = Versions.OldComposeCompiler
-    kotlinCompilerExtensionVersion = Versions.OldCompose
+    kotlinCompilerVersion = oldComposeCompiler
+    kotlinCompilerExtensionVersion = oldComposeVersion
   }
 }
 
@@ -45,8 +52,9 @@ dependencies {
 
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
-  androidTestImplementation(Dependencies.Compose.OldMaterial)
-  androidTestImplementation(Dependencies.Compose.OldTesting)
+  // Coordinates of the compose material artifact before it was renamed.
+  androidTestImplementation("androidx.ui:ui-material:$oldComposeVersion")
+  androidTestImplementation(Dependencies.Compose(oldComposeVersion).Testing)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)
   androidTestImplementation(Dependencies.InstrumentationTests.Runner)
   androidTestImplementation(Dependencies.Truth)

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -74,7 +74,7 @@ tasks.withType<KotlinCompile> {
 dependencies {
   // We don't want to bring any Compose dependencies in unless the consumer of this library is
   // bringing them in itself.
-  compileOnly(Dependencies.Compose.Tooling)
+  compileOnly(Dependencies.Compose().Tooling)
 
   implementation(kotlin("stdlib", Versions.KotlinStdlib))
 

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
   kotlin("android")
 }
 
+/** Use a separate property for the sample so we can test with different versions easily. */
+val sampleComposeVersion = Versions.Compose
+
 android {
   compileSdkVersion(30)
 
@@ -26,7 +29,7 @@ android {
 
   composeOptions {
     kotlinCompilerVersion = Versions.KotlinCompiler
-    kotlinCompilerExtensionVersion = Versions.Compose
+    kotlinCompilerExtensionVersion = sampleComposeVersion
   }
 }
 
@@ -47,10 +50,10 @@ dependencies {
 
   implementation(project(":radiography"))
   implementation(Dependencies.AppCompat)
-  implementation(Dependencies.Compose.Material)
-  implementation(Dependencies.Compose.Tooling)
+  implementation(Dependencies.Compose(sampleComposeVersion).Material)
+  implementation(Dependencies.Compose(sampleComposeVersion).Tooling)
 
-  androidTestImplementation(Dependencies.Compose.Testing)
+  androidTestImplementation(Dependencies.Compose(sampleComposeVersion).Testing)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)
   androidTestImplementation(Dependencies.InstrumentationTests.Runner)
 }


### PR DESCRIPTION
Makes the compose dependencies parameterized, so they can be easily overridden
for quickly testing different combinations.

Manually tested with alpha01 and sample on alpha02, and vice versa.