### PR TITLE
Merge separate kotlin compilation configuration blocks in gradle scripts.

### DIFF
--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -49,24 +49,20 @@ android {
 }
 
 tasks.withType<KotlinCompile> {
-  // Tests aren't part of the public API, don't turn explicit API mode on for them.
-  if (!name.contains("test", ignoreCase = true)) {
-    kotlinOptions {
-      // Require explicit public modifiers and types.
-      // TODO this should be moved to a top-level `kotlin { explicitApi() }` once that's working
-      //  for android projects, see https://youtrack.jetbrains.com/issue/KT-37652.
-      freeCompilerArgs = listOf("-Xexplicit-api=strict")
-    }
-  }
-}
-
-tasks.withType<KotlinCompile> {
   kotlinOptions {
-    freeCompilerArgs = listOf(
+    freeCompilerArgs = listOfNotNull(
         // allow-jvm-ir-dependencies is required to consume binaries built with the IR backend.
         // It doesn't change the bytecode that gets generated for this module.
         "-Xallow-jvm-ir-dependencies",
-        "-Xopt-in=kotlin.RequiresOptIn"
+        "-Xopt-in=kotlin.RequiresOptIn",
+
+        // Require explicit public modifiers and types.
+        // TODO this should be moved to a top-level `kotlin { explicitApi() }` once that's working
+        //  for android projects, see https://youtrack.jetbrains.com/issue/KT-37652.
+        "-Xexplicit-api=strict".takeUnless {
+          // Tests aren't part of the public API, don't turn explicit API mode on for them.
+          name.contains("test", ignoreCase = true)
+        }
     )
   }
 }

--- a/radiography/src/main/java/radiography/ScanScope.kt
+++ b/radiography/src/main/java/radiography/ScanScope.kt
@@ -9,8 +9,8 @@ package radiography
  *  - [ScanScopes.FocusedWindowScope]
  *  - [ScanScopes.singleViewScope]
  */
-fun interface ScanScope {
+public fun interface ScanScope {
 
   /** Returns the [ScannableView]s that scanning should start from. */
-  fun findRoots(): List<ScannableView>
+  public fun findRoots(): List<ScannableView>
 }

--- a/radiography/src/main/java/radiography/ScanScopes.kt
+++ b/radiography/src/main/java/radiography/ScanScopes.kt
@@ -8,21 +8,21 @@ import radiography.compose.composeRenderingError
 import radiography.compose.findTestTags
 import radiography.compose.isComposeAvailable
 
-object ScanScopes {
+public object ScanScopes {
 
   @JvmField
   internal val EmptyScope: ScanScope = ScanScope { emptyList() }
 
   /** Scans all the windows owned by the app. */
   @JvmField
-  val AllWindowsScope: ScanScope = ScanScope {
+  public val AllWindowsScope: ScanScope = ScanScope {
     WindowScanner.findAllRootViews()
         .map(::AndroidView)
   }
 
   /** Scans the window that currently has focus. */
   @JvmField
-  val FocusedWindowScope: ScanScope = ScanScope {
+  public val FocusedWindowScope: ScanScope = ScanScope {
     AllWindowsScope.findRoots()
         .filterIsInstance<AndroidView>()
         .filter { it.view.parent?.parent != null || it.view.hasWindowFocus() }
@@ -30,7 +30,7 @@ object ScanScopes {
 
   /** Scans the given [rootView]. */
   @JvmStatic
-  fun singleViewScope(rootView: View): ScanScope = ScanScope {
+  public fun singleViewScope(rootView: View): ScanScope = ScanScope {
     listOf(AndroidView(rootView))
   }
 
@@ -59,7 +59,7 @@ object ScanScopes {
   @ExperimentalRadiographyComposeApi
   @JvmStatic
   @JvmOverloads
-  fun composeTestTagScope(
+  public fun composeTestTagScope(
     testTag: String,
     inScope: ScanScope = AllWindowsScope
   ): ScanScope {

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -24,7 +24,7 @@ public sealed class ScannableView {
   /** The children of this view. */
   public abstract val children: Sequence<ScannableView>
 
-  public class AndroidView(val view: View) : ScannableView() {
+  public class AndroidView(public val view: View) : ScannableView() {
     override val displayName: String get() = view::class.java.simpleName
     override val children: Sequence<ScannableView> = view.scannableChildren()
 
@@ -39,9 +39,9 @@ public sealed class ScannableView {
   @ExperimentalRadiographyComposeApi
   public class ComposeView(
     override val displayName: String,
-    val width: Int,
-    val height: Int,
-    val modifiers: List<Modifier>,
+    public val width: Int,
+    public val height: Int,
+    public val modifiers: List<Modifier>,
     override val children: Sequence<ScannableView>
   ) : ScannableView() {
 

--- a/radiography/src/main/java/radiography/compose/ExperimentalRadiographyComposeApi.kt
+++ b/radiography/src/main/java/radiography/compose/ExperimentalRadiographyComposeApi.kt
@@ -4,4 +4,4 @@ package radiography.compose
     message = "This API is experimental, may only work with a specific version of Compose, " +
         "and may change or break at any time. Use with caution."
 )
-annotation class ExperimentalRadiographyComposeApi
+public annotation class ExperimentalRadiographyComposeApi


### PR DESCRIPTION
The duplicate blocks were overwriting the compiler args, so explicit API
mode was not actually being enabled.