### PR TITLE
Move internal code to internal package.

### DIFF
--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -39,7 +39,7 @@ import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.ViewStateRenderers.DefaultsNoPii
 import radiography.ViewStateRenderers.ViewRenderer
 import radiography.ViewStateRenderers.textViewRenderer
-import radiography.compose.ExperimentalRadiographyComposeApi
+import radiography.ExperimentalRadiographyComposeApi
 
 @OptIn(ExperimentalRadiographyComposeApi::class)
 class ComposeUiTest {

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -25,7 +25,7 @@ import org.junit.Test
 import radiography.ScannableView
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
-import radiography.compose.ExperimentalRadiographyComposeApi
+import radiography.ExperimentalRadiographyComposeApi
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -3,6 +3,9 @@ public final class radiography/AttributeAppendable {
 	public final fun append (Ljava/lang/CharSequence;)V
 }
 
+public abstract interface annotation class radiography/ExperimentalRadiographyComposeApi : java/lang/annotation/Annotation {
+}
+
 public final class radiography/Radiography {
 	public static final field INSTANCE Lradiography/Radiography;
 	public static final fun scan ()Ljava/lang/String;
@@ -88,8 +91,5 @@ public final class radiography/ViewStateRenderers {
 public final class radiography/ViewsKt {
 	public static final synthetic fun scan (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;)Ljava/lang/String;
 	public static synthetic fun scan$default (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;ILjava/lang/Object;)Ljava/lang/String;
-}
-
-public abstract interface annotation class radiography/compose/ExperimentalRadiographyComposeApi : java/lang/annotation/Annotation {
 }
 

--- a/radiography/src/main/java/radiography/ExperimentalRadiographyComposeApi.kt
+++ b/radiography/src/main/java/radiography/ExperimentalRadiographyComposeApi.kt
@@ -1,4 +1,4 @@
-package radiography.compose
+package radiography
 
 @RequiresOptIn(
     message = "This API is experimental, may only work with a specific version of Compose, " +

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -8,6 +8,7 @@ import radiography.Radiography.scan
 import radiography.ScanScopes.AllWindowsScope
 import radiography.ScannableView.AndroidView
 import radiography.ViewStateRenderers.DefaultsNoPii
+import radiography.internal.renderTreeString
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.SECONDS
 

--- a/radiography/src/main/java/radiography/ScanScopes.kt
+++ b/radiography/src/main/java/radiography/ScanScopes.kt
@@ -3,10 +3,10 @@ package radiography
 import android.view.View
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
-import radiography.compose.ExperimentalRadiographyComposeApi
-import radiography.compose.composeRenderingError
-import radiography.compose.findTestTags
-import radiography.compose.isComposeAvailable
+import radiography.internal.composeRenderingError
+import radiography.internal.findTestTags
+import radiography.internal.isComposeAvailable
+import radiography.internal.WindowScanner
 
 public object ScanScopes {
 

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -5,10 +5,9 @@ import android.view.ViewGroup
 import androidx.compose.ui.Modifier
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
-import radiography.compose.ComposeLayoutInfo
-import radiography.compose.ExperimentalRadiographyComposeApi
-import radiography.compose.getComposeScannableViews
-import radiography.compose.mightBeComposeView
+import radiography.internal.ComposeLayoutInfo
+import radiography.internal.getComposeScannableViews
+import radiography.internal.mightBeComposeView
 
 /**
  * Represents a logic view that can be rendered as a node in the view tree.

--- a/radiography/src/main/java/radiography/ViewFilters.kt
+++ b/radiography/src/main/java/radiography/ViewFilters.kt
@@ -3,8 +3,7 @@ package radiography
 import android.view.View
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
-import radiography.compose.ExperimentalRadiographyComposeApi
-import radiography.compose.findTestTags
+import radiography.internal.findTestTags
 
 public object ViewFilters {
 

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -12,8 +12,9 @@ import androidx.compose.ui.semantics.SemanticsProperties.Text
 import androidx.compose.ui.semantics.getOrNull
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
-import radiography.compose.ExperimentalRadiographyComposeApi
-import radiography.compose.isComposeAvailable
+import radiography.internal.isComposeAvailable
+import radiography.internal.ellipsize
+import radiography.internal.formatPixelDimensions
 
 @OptIn(ExperimentalRadiographyComposeApi::class)
 public object ViewStateRenderers {

--- a/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
@@ -1,4 +1,4 @@
-package radiography.compose
+package radiography.internal
 
 import android.view.View
 import androidx.compose.ui.Modifier

--- a/radiography/src/main/java/radiography/internal/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeViews.kt
@@ -1,4 +1,4 @@
-package radiography.compose
+package radiography.internal
 
 import android.util.SparseArray
 import android.view.View
@@ -8,6 +8,7 @@ import androidx.ui.tooling.asTree
 import radiography.ScannableView
 import radiography.ScannableView.ChildRenderingError
 import radiography.ScannableView.ComposeView
+import radiography.ExperimentalRadiographyComposeApi
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 private val VIEW_KEYED_TAGS_FIELD = View::class.java.getDeclaredField("mKeyedTags")

--- a/radiography/src/main/java/radiography/internal/RenderTreeString.kt
+++ b/radiography/src/main/java/radiography/internal/RenderTreeString.kt
@@ -1,4 +1,4 @@
-package radiography
+package radiography.internal
 
 import java.util.BitSet
 

--- a/radiography/src/main/java/radiography/internal/Semantics.kt
+++ b/radiography/src/main/java/radiography/internal/Semantics.kt
@@ -1,8 +1,9 @@
-package radiography.compose
+package radiography.internal
 
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import radiography.ScannableView.ComposeView
+import radiography.ExperimentalRadiographyComposeApi
 
 /** Returns all tag strings set on the composable via `Modifier.testTag`. */
 @OptIn(ExperimentalRadiographyComposeApi::class)

--- a/radiography/src/main/java/radiography/internal/Strings.kt
+++ b/radiography/src/main/java/radiography/internal/Strings.kt
@@ -1,4 +1,4 @@
-package radiography
+package radiography.internal
 
 internal fun CharSequence.ellipsize(maxLength: Int): CharSequence =
   if (length > maxLength) "${subSequence(0, maxLength - 1)}…" else this

--- a/radiography/src/main/java/radiography/internal/WindowScanner.kt
+++ b/radiography/src/main/java/radiography/internal/WindowScanner.kt
@@ -1,4 +1,4 @@
-package radiography
+package radiography.internal
 
 import android.os.Build.VERSION
 import android.view.View

--- a/radiography/src/test/java/radiography/RenderTreeStringTest.kt
+++ b/radiography/src/test/java/radiography/RenderTreeStringTest.kt
@@ -2,6 +2,7 @@ package radiography
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import radiography.internal.renderTreeString
 
 class RenderTreeStringTest {
 

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.ui.tooling.preview.Preview
 import com.squareup.radiography.sample.compose.R.drawable
+import radiography.ExperimentalRadiographyComposeApi
 import radiography.Radiography
 import radiography.ScanScopes.FocusedWindowScope
 import radiography.ViewFilters.skipComposeTestTagsFilter
@@ -51,7 +52,6 @@ import radiography.ViewStateRenderers.DefaultsNoPii
 import radiography.ViewStateRenderers.ViewRenderer
 import radiography.ViewStateRenderers.androidViewStateRendererFor
 import radiography.ViewStateRenderers.textViewRenderer
-import radiography.compose.ExperimentalRadiographyComposeApi
 
 internal const val TEXT_FIELD_TEST_TAG = "text-field"
 internal const val LIVE_HIERARCHY_TEST_TAG = "live-hierarchy"


### PR DESCRIPTION
Also drops the `radiography.compose` package entirely. The only public API this ends up affecting is the experimental annotation.

Closes #84.