### PR TITLE
Rename showTextValue parameter to renderTextValue.

### DIFF
--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -144,7 +144,7 @@ class ComposeUiTest {
     }
 
     val hierarchy = runOnIdle {
-      Radiography.scan(viewStateRenderers = listOf(textViewRenderer(showTextValue = true)))
+      Radiography.scan(viewStateRenderers = listOf(textViewRenderer(renderTextValue = true)))
     }
 
     assertThat(hierarchy).doesNotContain("text-length")
@@ -160,7 +160,7 @@ class ComposeUiTest {
       Radiography.scan(
           viewStateRenderers = listOf(
               textViewRenderer(
-                  showTextValue = true,
+                  renderTextValue = true,
                   textValueMaxLength = 11
               )
           )
@@ -190,7 +190,7 @@ class ComposeUiTest {
     }
 
     val hierarchy = runOnIdle {
-      Radiography.scan(viewStateRenderers = listOf(textViewRenderer(showTextValue = true)))
+      Radiography.scan(viewStateRenderers = listOf(textViewRenderer(renderTextValue = true)))
     }
 
     assertThat(hierarchy).contains("text:\"Baguette Avec Fromage\"")
@@ -205,7 +205,7 @@ class ComposeUiTest {
       Radiography.scan(
           viewStateRenderers = listOf(
               textViewRenderer(
-                  showTextValue = true,
+                  renderTextValue = true,
                   textValueMaxLength = 11
               )
           )

--- a/radiography/src/test/java/radiography/RadiographyTest.kt
+++ b/radiography/src/test/java/radiography/RadiographyTest.kt
@@ -68,7 +68,7 @@ class RadiographyTest {
   @Test fun textViewContents() {
     val view = TextView(context)
     view.text = "Baguette Avec Fromage"
-    view.scan(viewStateRenderers = listOf(textViewRenderer(showTextValue = true)))
+    view.scan(viewStateRenderers = listOf(textViewRenderer(renderTextValue = true)))
         .also {
           assertThat(it).doesNotContain("text-length")
           assertThat(it).contains("text:\"Baguette Avec Fromage\"")
@@ -81,7 +81,7 @@ class RadiographyTest {
     view.scan(
         viewStateRenderers = listOf(
             textViewRenderer(
-                showTextValue = true,
+                renderTextValue = true,
                 textValueMaxLength = 11
             )
         )

--- a/radiography/src/test/java/radiography/ViewStateRenderersTest.kt
+++ b/radiography/src/test/java/radiography/ViewStateRenderersTest.kt
@@ -51,7 +51,7 @@ class ViewStateRenderersTest {
 
     val result = buildString {
       AttributeAppendable(this)
-          .appendTextValue(text, showTextValue = true, textValueMaxLength = 5)
+          .appendTextValue(text, renderTextValue = true, textValueMaxLength = 5)
     }
 
     assertThat(result).isEqualTo("""text:"hell…", text-length:11""")
@@ -62,7 +62,7 @@ class ViewStateRenderersTest {
 
     val result = buildString {
       AttributeAppendable(this)
-          .appendTextValue(text, showTextValue = true, textValueMaxLength = 11)
+          .appendTextValue(text, renderTextValue = true, textValueMaxLength = 11)
     }
 
     assertThat(result).isEqualTo("""text:"hello world"""")
@@ -73,7 +73,7 @@ class ViewStateRenderersTest {
 
     val result = buildString {
       AttributeAppendable(this)
-          .appendTextValue(text, showTextValue = true, textValueMaxLength = 100)
+          .appendTextValue(text, renderTextValue = true, textValueMaxLength = 100)
     }
 
     assertThat(result).isEqualTo("""text:"hello world"""")
@@ -84,7 +84,7 @@ class ViewStateRenderersTest {
 
     val result = buildString {
       AttributeAppendable(this)
-          .appendTextValue(text, showTextValue = false, textValueMaxLength = 0)
+          .appendTextValue(text, renderTextValue = false, textValueMaxLength = 0)
     }
 
     assertThat(result).isEqualTo("""text-length:11""")

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
@@ -165,7 +165,7 @@ private fun showSelectionDialog(context: Context) {
         Radiography.scan(
             viewStateRenderers = listOf(
                 ViewRenderer,
-                textViewRenderer(showTextValue = true, textValueMaxLength = 4),
+                textViewRenderer(renderTextValue = true, textValueMaxLength = 4),
                 CheckableRenderer,
             )
         )

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : Activity() {
               viewStateRenderers = listOf(
                   ViewStateRenderers.ViewRenderer,
                   ViewStateRenderers.textViewRenderer(
-                      showTextValue = true, textValueMaxLength = 4
+                      renderTextValue = true, textValueMaxLength = 4
                   ),
                   ViewStateRenderers.CheckableRenderer
               )


### PR DESCRIPTION
Fixes #73.

`textViewRenderer(renderText = false)` kind of looks like a no-op – the subtle distinction between “text” and “text view” is too important imo. “text value” and “text view” is a little more contrastive I think.

```kotlin
public fun textViewRenderer(
    renderTextValue: Boolean = false,
    textValueMaxLength: Int = Int.MAX_VALUE
  )
```

Either way, we should use the same term in both params.