### PR TITLE
Sort skip ids before using in binary search

### DIFF
--- a/radiography/src/main/java/radiography/ViewFilters.kt
+++ b/radiography/src/main/java/radiography/ViewFilters.kt
@@ -15,11 +15,13 @@ public object ViewFilters {
    * Filters out views with ids matching [skippedIds] from the output of [Radiography.scan].
    */
   @JvmStatic
-  public fun skipIdsViewFilter(vararg skippedIds: Int): ViewFilter =
-    androidViewFilterFor<View> { view ->
+  public fun skipIdsViewFilter(vararg skippedIds: Int): ViewFilter {
+    val sortedIds = skippedIds.sortedArray()
+    return androidViewFilterFor<View> { view ->
       val viewId = view.id
-      (viewId == View.NO_ID || skippedIds.isEmpty() || skippedIds.binarySearch(viewId) < 0)
+      (viewId == View.NO_ID || sortedIds.isEmpty() || sortedIds.binarySearch(viewId) < 0)
     }
+  }
 
   /**
    * Filters out composables with [`Modifier.testTag`][androidx.compose.ui.platform.testTag]

--- a/radiography/src/test/java/radiography/RadiographyTest.kt
+++ b/radiography/src/test/java/radiography/RadiographyTest.kt
@@ -106,7 +106,7 @@ class RadiographyTest {
         }
   }
 
-  @Test fun skipIds() {
+  @Test fun `skipIds with single input`() {
     val layout = FrameLayout(context)
     val view = Button(context).apply {
       id = 42
@@ -117,6 +117,19 @@ class RadiographyTest {
           assertThat(it).contains("FrameLayout")
           assertThat(it).doesNotContain("Button")
         }
+  }
+
+  @Test fun `skipIds with unsorted inputs`() {
+    val layout = FrameLayout(context)
+    val view = Button(context).apply {
+      id = 42
+    }
+    layout.addView(view)
+    layout.scan(viewFilter = skipIdsViewFilter(42, 2, 6))
+            .also {
+              assertThat(it).contains("FrameLayout")
+              assertThat(it).doesNotContain("Button")
+            }
   }
 
   @Test fun combineFilters() {


### PR DESCRIPTION
`skipIdsViewFilter` is using a binary search without making sure the view ids are sorted. This PR simply sorts it when creating the view filter. Added a test that previously failed because the list is unsorted.