### PR TITLE
Upgrade Compose and AGP to latest versions.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,12 +8,12 @@ object Versions {
   /** Use a lower version of the stdlib so the library can be consumed by lower kotlin versions. */
   val KotlinStdlib = System.getProperty("square.kotlinStdlibVersion") ?: "1.3.72"
 
-  const val Compose = "1.0.0-alpha02"
+  const val Compose = "1.0.0-alpha04"
 }
 
 object Dependencies {
   object Build {
-    const val Android = "com.android.tools.build:gradle:4.2.0-alpha11"
+    const val Android = "com.android.tools.build:gradle:4.2.0-alpha13"
     const val MavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.12.0"
     val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KotlinCompiler}"
     const val Ktlint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeTestRules.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeTestRules.kt
@@ -1,0 +1,21 @@
+package radiography.test.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.ui.test.ComposeTestRuleJUnit
+
+/**
+ * Calls [ComposeTestRuleJUnit.setContent] but wraps [content] with a [Box] to emulate how real
+ * apps usually have one or more root-level composables. Compose UI tests should use this instead
+ * of `setContent` to insulate them from the implementation details of the internal composable graph
+ * that `setContent` creates behind the scenes and might change between releases.
+ *
+ * E.g. If you use `setContent` directly, root children will all show up as `Providers` in alpha04.
+ */
+fun ComposeTestRuleJUnit.setContentWithExplicitRoot(content: @Composable () -> Unit) {
+  setContent {
+    Box {
+      content()
+    }
+  }
+}

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -2,15 +2,16 @@ package radiography.test.compose
 
 import android.view.ViewGroup.LayoutParams
 import android.widget.TextView
-import androidx.compose.foundation.Box
 import androidx.compose.foundation.Text
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Stack
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SlotTable
 import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.Modifier
@@ -28,10 +29,10 @@ import androidx.compose.ui.semantics.SemanticsProperties.TestTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.ui.test.createComposeRule
-import androidx.ui.test.runOnIdle
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
+import radiography.ExperimentalRadiographyComposeApi
 import radiography.Radiography
 import radiography.ScanScopes.composeTestTagScope
 import radiography.ViewFilters.skipComposeTestTagsFilter
@@ -39,7 +40,6 @@ import radiography.ViewStateRenderers.DefaultsIncludingPii
 import radiography.ViewStateRenderers.DefaultsNoPii
 import radiography.ViewStateRenderers.ViewRenderer
 import radiography.ViewStateRenderers.textViewRenderer
-import radiography.ExperimentalRadiographyComposeApi
 
 @OptIn(ExperimentalRadiographyComposeApi::class)
 class ComposeUiTest {
@@ -48,22 +48,22 @@ class ComposeUiTest {
   val composeRule = createComposeRule()
 
   @Test fun when_includingPii_then_hierarchyContainsText() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Text("FooBar")
     }
 
-    runOnIdle {
+    composeRule.runOnIdle {
       val hierarchy = Radiography.scan(viewStateRenderers = DefaultsIncludingPii)
       assertThat(hierarchy).contains("FooBar")
     }
   }
 
   @Test fun when_noPii_then_hierarchyExcludesText() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Text("FooBar")
     }
 
-    runOnIdle {
+    composeRule.runOnIdle {
       val hierarchy = Radiography.scan(viewStateRenderers = DefaultsNoPii)
       assertThat(hierarchy).doesNotContain("FooBar")
       assertThat(hierarchy).contains("text-length:6")
@@ -71,14 +71,14 @@ class ComposeUiTest {
   }
 
   @Test fun viewSizeReported() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       val (width, height) = with(DensityAmbient.current) {
         Pair(30.toDp(), 40.toDp())
       }
       Box(modifier = Modifier.size(width, height))
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(viewStateRenderers = listOf(ViewRenderer))
     }
 
@@ -86,11 +86,11 @@ class ComposeUiTest {
   }
 
   @Test fun zeroSizeViewReported() {
-    composeRule.setContent {
-      Box()
+    composeRule.setContentWithExplicitRoot {
+      Box(Modifier)
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(viewStateRenderers = emptyList())
     }
 
@@ -98,7 +98,7 @@ class ComposeUiTest {
   }
 
   @Test fun semanticsAreReported() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Box(Modifier.semantics { set(TestTag, "test tag") })
       Box(Modifier.semantics { set(AccessibilityLabel, "acc label") })
       Box(Modifier.semantics { set(AccessibilityValue, "acc value") })
@@ -110,7 +110,7 @@ class ComposeUiTest {
       Box(Modifier.semantics { set(IsPopup, Unit) })
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan()
     }
 
@@ -126,11 +126,11 @@ class ComposeUiTest {
   }
 
   @Test fun checkableChecked() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Checkbox(checked = true, onCheckedChange = {})
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(viewStateRenderers = listOf(ViewRenderer))
     }
 
@@ -139,11 +139,11 @@ class ComposeUiTest {
   }
 
   @Test fun textContents() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Text("Baguette Avec Fromage")
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(viewStateRenderers = listOf(textViewRenderer(renderTextValue = true)))
     }
 
@@ -152,11 +152,11 @@ class ComposeUiTest {
   }
 
   @Test fun textContentsEllipsized() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Text("Baguette Avec Fromage")
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(
           viewStateRenderers = listOf(
               textViewRenderer(
@@ -172,11 +172,11 @@ class ComposeUiTest {
   }
 
   @Test fun textExcludedByDefault() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Text("Baguette Avec Fromage")
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan()
     }
 
@@ -185,11 +185,11 @@ class ComposeUiTest {
   }
 
   @Test fun textFieldContents() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       TextField("Baguette Avec Fromage", onValueChange = {}, label = {})
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(viewStateRenderers = listOf(textViewRenderer(renderTextValue = true)))
     }
 
@@ -197,11 +197,11 @@ class ComposeUiTest {
   }
 
   @Test fun textFieldContentsEllipsized() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       TextField("Baguette Avec Fromage", onValueChange = {}, label = {})
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(
           viewStateRenderers = listOf(
               textViewRenderer(
@@ -217,13 +217,13 @@ class ComposeUiTest {
   }
 
   @Test fun skipTestTags() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Box {
         Button(modifier = Modifier.testTag("42"), onClick = {}, content = {})
       }
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(viewFilter = skipComposeTestTagsFilter("42"))
     }
 
@@ -233,31 +233,31 @@ class ComposeUiTest {
 
   @Test fun nestedLayouts() {
     val slotTable = Ref<SlotTable>()
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       slotTable.value = currentComposer.slotTable
 
-      Stack(Modifier.testTag("root")) {
-        Box()
+      Box(Modifier.testTag("root")) {
+        Box(Modifier)
         Column {
-          Box()
-          Box()
+          Box(Modifier)
+          Box(Modifier)
         }
         Row {
-          Box()
-          Box()
+          Box(Modifier)
+          Box(Modifier)
         }
       }
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(composeTestTagScope("root"))
     }
 
     @Suppress("RemoveCurlyBracesFromTemplate")
     assertThat(hierarchy).contains(
         """
-          Stack:
-          ${BLANK}Stack { test-tag:"root" }
+          Box:
+          ${BLANK}Box { test-tag:"root" }
           ${BLANK}├─Box {  }
           ${BLANK}├─Column {  }
           ${BLANK}│ ├─Box {  }
@@ -271,7 +271,7 @@ class ComposeUiTest {
 
   @Test fun nestedViewsInsideLayouts() {
     val slotTable = Ref<SlotTable>()
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       slotTable.value = currentComposer.slotTable
 
       Box(Modifier.testTag("root")) {
@@ -281,7 +281,7 @@ class ComposeUiTest {
       }
     }
 
-    val hierarchy = runOnIdle {
+    val hierarchy = composeRule.runOnIdle {
       Radiography.scan(composeTestTagScope("root"))
     }
 
@@ -297,6 +297,20 @@ class ComposeUiTest {
     )
     // But this view description should show up at some point.
     assertThat(hierarchy).contains("╰─TextView { 0×0px, text-length:0 }")
+  }
+
+  /**
+   * Wrapper around [Box] that is intentionally not inline, so it shows up in the slot table.
+   */
+  @Composable private fun ParentBox(
+    modifier: Modifier = Modifier,
+    children: (@Composable BoxScope.() -> Unit)? = null
+  ) {
+    if (children == null) {
+      Box(modifier)
+    } else {
+      Box(modifier, children = children)
+    }
   }
 
   companion object {

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -3,8 +3,8 @@ package radiography.test.compose
 import android.view.View
 import android.widget.TextView
 import androidx.activity.ComponentActivity
-import androidx.compose.foundation.Box
 import androidx.compose.foundation.Text
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
@@ -17,8 +17,7 @@ import androidx.compose.ui.platform.DensityAmbient
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import androidx.ui.test.android.createAndroidComposeRule
-import androidx.ui.test.runOnIdle
+import androidx.ui.test.createAndroidComposeRule
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -36,7 +35,7 @@ class ComposeViewTest {
   val composeRule = createAndroidComposeRule<ComponentActivity>()
 
   @Test fun androidView_children_includes_ComposeViews() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Text("hello")
     }
 
@@ -46,7 +45,7 @@ class ComposeViewTest {
   }
 
   @Test fun composeView_children_includes_AndroidView() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Column {
         androidx.compose.ui.viewinterop.AndroidView(::TextView)
       }
@@ -61,11 +60,11 @@ class ComposeViewTest {
   }
 
   @Test fun composeView_reports_children() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Column {
         Text("hello")
         Button(onClick = {}) {
-          Box()
+          Box(Modifier)
         }
       }
     }
@@ -82,7 +81,7 @@ class ComposeViewTest {
   }
 
   @Test fun composeView_reports_LayoutModifiers() {
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       Box(TestModifier)
     }
 
@@ -93,12 +92,12 @@ class ComposeViewTest {
 
   @Test fun composeView_reports_size() {
     var density: Density? = null
-    composeRule.setContent {
+    composeRule.setContentWithExplicitRoot {
       density = DensityAmbient.current
       Box(Modifier.size(30.dp, 40.dp))
     }
 
-    val (widthPx, heightPx) = runOnIdle {
+    val (widthPx, heightPx) = composeRule.runOnIdle {
       with(density!!) {
         Pair(30.dp.toIntPx(), 40.dp.toIntPx())
       }

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
  * Allows using a different version of Compose to validate that we degrade gracefully on apps
  * built with unsupported Compose versions.
  */
-val oldComposeVersion = "0.1.0-dev12"
-val oldComposeCompiler = "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
+val oldComposeVersion = "1.0.0-alpha04"
+val oldComposeCompiler = Versions.KotlinCompiler
 
 android {
   compileSdkVersion(30)
@@ -42,7 +42,11 @@ android {
 tasks.withType<KotlinCompile> {
   kotlinOptions {
     jvmTarget = "1.8"
-    freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
+    freeCompilerArgs = listOf(
+        "-Xallow-jvm-ir-dependencies",
+        "-Xskip-prerelease-check",
+        "-Xopt-in=kotlin.RequiresOptIn"
+    )
   }
 }
 
@@ -52,8 +56,7 @@ dependencies {
 
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
-  // Coordinates of the compose material artifact before it was renamed.
-  androidTestImplementation("androidx.ui:ui-material:$oldComposeVersion")
+  androidTestImplementation(Dependencies.Compose(oldComposeVersion).Material)
   androidTestImplementation(Dependencies.Compose(oldComposeVersion).Testing)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)
   androidTestImplementation(Dependencies.InstrumentationTests.Runner)

--- a/compose-unsupported-tests/src/androidTest/java/radiography/test/compose/ComposeUnsupportedTest.kt
+++ b/compose-unsupported-tests/src/androidTest/java/radiography/test/compose/ComposeUnsupportedTest.kt
@@ -1,8 +1,7 @@
 package radiography.test.compose
 
-import androidx.ui.foundation.Text
+import androidx.compose.foundation.Text
 import androidx.ui.test.createComposeRule
-import androidx.ui.test.runOnIdleCompose
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -19,7 +18,7 @@ class ComposeUnsupportedTest {
       Text("FooBar")
     }
 
-    runOnIdleCompose {
+    composeRule.runOnIdle {
       val hierarchy = Radiography.scan(viewStateRenderers = DefaultsIncludingPii)
       assertThat(hierarchy).doesNotContain("FooBar")
       assertThat(hierarchy).contains(

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 /** Use a separate property for the sample so we can test with different versions easily. */
-val sampleComposeVersion = "1.0.0-alpha03"
+val sampleComposeVersion = "1.0.0-alpha04"
 
 android {
   compileSdkVersion(30)
@@ -30,6 +30,11 @@ android {
   composeOptions {
     kotlinCompilerVersion = Versions.KotlinCompiler
     kotlinCompilerExtensionVersion = sampleComposeVersion
+  }
+
+  lintOptions {
+    // Workaround lint bug.
+    disable("InvalidFragmentVersionForActivityResult")
   }
 }
 

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/RadiographyLogo.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/RadiographyLogo.kt
@@ -1,7 +1,7 @@
 package com.squareup.radiography.sample.compose
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Stack
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.wrapContentSize
@@ -32,7 +32,7 @@ import kotlin.math.roundToInt
   val innerImage = imageResource(R.drawable.logo_inner)
   val aspectRatio = outerImage.width.toFloat() / outerImage.height.toFloat()
 
-  Stack(modifier.aspectRatio(aspectRatio)) {
+  Box(modifier.aspectRatio(aspectRatio)) {
     Image(outerImage)
     InfiniteMirror(
         centerOffsetFraction = Offset(.5f, .59f),
@@ -71,7 +71,7 @@ import kotlin.math.roundToInt
 
     // Draw the content and recurse at the next scale. Note that the centering is being performed by
     // wrapContentSize above, this modifier just needs to scale.
-    Stack(Modifier.fillMaxSize(scaleFactor)) {
+    Box(Modifier.fillMaxSize(scaleFactor)) {
       content()
       InfiniteMirror(centerOffsetFraction, scaleFactor, minimumSizeThreshold, content)
     }


### PR DESCRIPTION
They both have to be upgraded at the same time unfortunately, Compose 1.0.0-alpha04 and AGP 4.2.0-alpha13 are mutually dependent. 

And to avoid having to configure two separate versions of AGP, the backwards-compatibility test is upgraded to the lastest version as well. This means it's not currently actually testing anything, but we should leave it at this version going forward.