### PR TITLE
Remove the API 1.3 workaround. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 println("Building with Kotlin compiler version ${Versions.KotlinCompiler}")
-println("Building with Kotlin stdlib version ${Versions.KotlinStdlib}")
 
 buildscript {
   repositories {
@@ -78,8 +77,6 @@ subprojects {
       }
 
       jvmTarget = "1.6"
-      // Required to avoid warnings about using older stdlib version.
-      apiVersion = "1.3"
     }
   }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,9 +5,6 @@ object Versions {
    */
   val KotlinCompiler = System.getProperty("square.kotlinVersion") ?: "1.4.10"
 
-  /** Use a lower version of the stdlib so the library can be consumed by lower kotlin versions. */
-  val KotlinStdlib = System.getProperty("square.kotlinStdlibVersion") ?: "1.3.72"
-
   const val Compose = "1.0.0-alpha05"
 }
 

--- a/compose-tests/build.gradle.kts
+++ b/compose-tests/build.gradle.kts
@@ -35,9 +35,6 @@ android {
 tasks.withType<KotlinCompile> {
   kotlinOptions {
     jvmTarget = "1.8"
-    // Override lower API version from root build.gradle.kts since this module is using the new
-    // stdlib.
-    apiVersion = "1.4"
     freeCompilerArgs = listOf(
         "-Xallow-jvm-ir-dependencies",
         "-Xskip-prerelease-check",
@@ -47,9 +44,6 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-  // Don't use Versions.KotlinStdlib for Kotlin stdlib, since this module actually uses the Compose
-  // compiler and needs the latest stdlib.
-
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
   androidTestImplementation(Dependencies.Compose().Material)

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -51,9 +51,6 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-  // Don't use Versions.KotlinStdlib for Kotlin stdlib, since this module actually uses the Compose
-  // compiler and needs the latest stdlib.
-
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
   androidTestImplementation(Dependencies.Compose(oldComposeVersion).Material)

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -72,8 +72,6 @@ dependencies {
   // bringing them in itself.
   compileOnly(Dependencies.Compose().Tooling)
 
-  implementation(kotlin("stdlib", Versions.KotlinStdlib))
-
   testImplementation(Dependencies.JUnit)
   testImplementation(Dependencies.Mockito)
   testImplementation(Dependencies.Robolectric)

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -80,19 +80,19 @@ public object Radiography {
     if (!viewFilter.matches(rootView)) return
 
     if (length > 0) {
-      appendln()
+      appendLine()
     }
 
     val androidView = (rootView as? AndroidView)?.view
     val layoutParams = androidView?.layoutParams
     val title = (layoutParams as? WindowManager.LayoutParams)?.title?.toString()
         ?: rootView.displayName
-    appendln("$title:")
+    appendLine("$title:")
 
     val startPosition = length
     try {
       androidView?.let {
-        appendln("window-focus:${it.hasWindowFocus()}")
+        appendLine("window-focus:${it.hasWindowFocus()}")
       }
       renderScannableViewTree(this, rootView, viewStateRenderers, viewFilter)
     } catch (e: Throwable) {

--- a/radiography/src/main/java/radiography/internal/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeViews.kt
@@ -81,7 +81,7 @@ internal fun composeRenderingError(exception: LinkageError?): ScannableView {
   val message = buildString {
     append(COMPOSE_UNSUPPORTED_MESSAGE)
     exception?.let {
-      appendln().append("Error: $exception")
+      appendLine().append("Error: $exception")
     }
   }
   return ChildRenderingError(message)

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -55,9 +55,6 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-  // Don't use Versions.KotlinStdlib for Kotlin stdlib, since this module actually uses the Compose
-  // compiler and needs the latest stdlib.
-
   implementation(project(":radiography"))
   implementation(Dependencies.AppCompat)
   implementation(Dependencies.Compose(sampleComposeVersion).Material)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -36,7 +36,6 @@ android {
 }
 
 dependencies {
-  implementation(kotlin("stdlib", Versions.KotlinStdlib))
   implementation(project(":radiography"))
   implementation(Dependencies.AppCompat)
   implementation(Dependencies.ConstraintLayout)


### PR DESCRIPTION
It's not longer needed and the latest standard library can be used.