### PR TITLE
Fix UI Tests reports

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,7 +50,8 @@ jobs:
           script: ./gradlew connectedCheck --no-build-cache --no-daemon --stacktrace
 
       - name: Upload results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: insrumentation-test-results
+          name: instrumentation-test-results ${{ matrix.api-level }}
           path: ./**/build/reports/androidTests/connected/**


### PR DESCRIPTION
* Enable result uploading on failure (default is only success)
* Rename uploaded artifact so that we get one file per API level instead of overwriting the same file N times.