### PR TITLE
Allow any type of ScannableView

### DIFF
--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -29,7 +29,7 @@ public final class radiography/ScanScopes {
 	public static final fun singleViewScope (Landroid/view/View;)Lradiography/ScanScope;
 }
 
-public abstract class radiography/ScannableView {
+public abstract interface class radiography/ScannableView {
 	public abstract fun getChildren ()Lkotlin/sequences/Sequence;
 	public abstract fun getDisplayName ()Ljava/lang/String;
 }

--- a/radiography/src/main/java/radiography/Radiography.kt
+++ b/radiography/src/main/java/radiography/Radiography.kt
@@ -1,7 +1,5 @@
 package radiography
 
-import android.os.Handler
-import android.os.Looper
 import android.view.View
 import android.view.WindowManager
 import androidx.annotation.VisibleForTesting
@@ -23,9 +21,7 @@ public object Radiography {
    * Scans the view hierarchies and pretty print them to a [String].
    *
    * You should generally call this method from the main thread, as views are meant to be accessed
-   * from a single thread. If you call this from a background thread, this will schedule a message
-   * to the main thread to retrieve the view hierarchy from there and will wait up to 5 seconds
-   * or return an error message. This method will never throw, any thrown exception will have
+   * from a single thread. This method will never throw, any thrown exception will have
    * its message included in the returned string.
    *
    * @param scanScope the [ScanScope] that determines what to scan. [AllWindowsScope] by default.
@@ -52,27 +48,11 @@ public object Radiography {
     }
 
     roots.forEach { scanRoot ->
-      // The entire view tree is single threaded, and that's typically the main thread, but
-      // it doesn't have to be, and we don't know where the passed in view is coming from.
-      val viewLooper = (scanRoot as? AndroidView)?.view?.handler?.looper
-        ?: Looper.getMainLooper()!!
-
-      if (viewLooper.thread == Thread.currentThread()) {
-        scanFromLooperThread(scanRoot, viewStateRenderers, viewFilter)
-      } else {
-        val latch = CountDownLatch(1)
-        Handler(viewLooper).post {
-          scanFromLooperThread(scanRoot, viewStateRenderers, viewFilter)
-          latch.countDown()
-        }
-        if (!latch.await(5, SECONDS)) {
-          return "Could not retrieve view hierarchy from main thread after 5 seconds wait"
-        }
-      }
+      scanSingleRoot(scanRoot, viewStateRenderers, viewFilter)
     }
   }
 
-  private fun StringBuilder.scanFromLooperThread(
+  private fun StringBuilder.scanSingleRoot(
     rootView: ScannableView,
     viewStateRenderers: List<ViewStateRenderer>,
     viewFilter: ViewFilter

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -18,15 +18,15 @@ import radiography.internal.mightBeComposeView
  * Can either be an actual Android [View] ([AndroidView]) or a grouping of Composables that roughly
  * represents the concept of a logical "view" ([ComposeView]).
  */
-public sealed class ScannableView {
+public interface ScannableView {
 
   /** The string that be used to identify the type of the view in the rendered output. */
-  public abstract val displayName: String
+  public val displayName: String
 
   /** The children of this view. */
-  public abstract val children: Sequence<ScannableView>
+  public val children: Sequence<ScannableView>
 
-  public class AndroidView(public val view: View) : ScannableView() {
+  public class AndroidView(public val view: View) : ScannableView {
     override val displayName: String get() = view::class.java.simpleName
     override val children: Sequence<ScannableView> = view.scannableChildren()
 
@@ -45,7 +45,7 @@ public sealed class ScannableView {
     public val height: Int,
     public val modifiers: List<Modifier>,
     override val children: Sequence<ScannableView>
-  ) : ScannableView() {
+  ) : ScannableView {
     override fun toString(): String = "${ComposeView::class.java.simpleName}($displayName)"
   }
 
@@ -57,7 +57,7 @@ public sealed class ScannableView {
    * return the error message along with any portion of the tree that was rendered before the
    * exception was thrown.
    */
-  public class ChildRenderingError(private val message: String) : ScannableView() {
+  public class ChildRenderingError(private val message: String) : ScannableView {
     override val displayName: String get() = message
     override val children: Sequence<ScannableView> get() = emptySequence()
   }

--- a/radiography/src/test/java/radiography/RadiographyTest.kt
+++ b/radiography/src/test/java/radiography/RadiographyTest.kt
@@ -208,6 +208,35 @@ internal class RadiographyTest {
     assertThat(builder.toString()).isEqualTo("${BLANK}View\n")
   }
 
+  @Test fun `custom ScannableView details reported`() {
+    class Node(override val displayName: String) : ScannableView {
+      val mutableChildren = mutableListOf<Node>()
+
+      override val children: Sequence<ScannableView>
+        get() = mutableChildren.asSequence()
+    }
+
+    val root = Node("Root").apply {
+      mutableChildren += Node("Child A")
+      mutableChildren += Node("Child B")
+    }
+
+    val prettyHierarchy = Radiography.scan(
+      scanScope = ScanScope {
+        listOf(root)
+      }
+    )
+    assertThat(prettyHierarchy).isEqualTo(
+      """
+      |Root:
+      |${BLANK}Root
+      |${BLANK}├─Child A
+      |${BLANK}╰─Child B
+      |
+      """.trimMargin()
+    )
+  }
+
   companion object {
     private const val BLANK = '\u00a0'
   }


### PR DESCRIPTION
 Note: there's more work to make this not Android dependent. Notably refs to the WindowManager which likely belong to displayName for Views instead (?)