### PR TITLE
Enable emulator for API 30 in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,8 +33,7 @@ jobs:
           - 23
           - 26
           - 29
-          # The 30 emulator seems to be broken. See #130.
-          #- 30
+          - 30
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11


### PR DESCRIPTION
After the updates to the android-emulator-runner to run on 2 cores. It looks like the tests are running well on API 30:
https://github.com/AfzalivE/radiography/pull/1/checks?check_run_id=2040687033

API 23 timed out in that run but 30 went well.