### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ will scan all the windows owned by your app.
 val prettyHierarchy = someView.scan()
 
 // Render only the view hierarchy from the focused window, if any.
-val prettyHierarchy = Radiography.scan(scanScope = FocusedWindowScanScope)
+val prettyHierarchy = Radiography.scan(scanScope = FocusedWindowScope)
 
 // Filter out views with specific ids.
 val prettyHierarchy = Radiography.scan(viewFilter = skipIdsViewFilter(R.id.debug_drawer))


### PR DESCRIPTION
Fix wrong name for `FocusedWindowScope` in `README.md`.