### PR TITLE
Support Compose 1.5

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Build with Gradle
       run: ./gradlew build
 
@@ -36,10 +36,10 @@ jobs:
           - 30
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Change Log
 ==========
 
+Version 3.0.0
+-------------
+
+_2023-10-30_
+
+Compose 1.5 is now supported. Due to breaking API changes within the Compose runtime, this version
+is not compatible with earlier versions of Compose. If you need to use an earlier version of Compose,
+use a 2.x version of Radiography.
+
+The ScannableView.ComposeView has a new property, `semanticsConfigurations`, which exposes SemanticsConfiguration objects
+from both Modifiers and the new Semantics tree. In newer versions of Compose, SemanticsConfigurations cannot
+be read from the Modifier list, and are present only in the Semantics tree, 
+so if you were previously using the `modifiers` property for this you should switch to
+using `semanticsConfigurations` instead.
+
 Version 2.4.1
 -------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-If you would like to contribute code to Workflow you can do so through GitHub by
+If you would like to contribute code to Radiography you can do so through GitHub by
 forking the repository and sending a pull request.
 
 When submitting code, please make every effort to follow existing conventions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,6 @@ subprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
 
   apply(plugin = "org.jlleitschuh.gradle.ktlint")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,3 @@ plugins {
 repositories {
   mavenCentral()
 }
-
-kotlinDslPluginOptions {
-  experimentalWarning.set(false)
-}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -38,7 +38,7 @@ object Dependencies {
   object InstrumentationTests {
     const val Core = "androidx.test:core:${Versions.AndroidXTest}"
     const val Espresso = "androidx.test.espresso:espresso-core:3.5.1"
-    const val JUnit = "androidx.test.ext:junit:1.1.3"
+    const val JUnit = "androidx.test.ext:junit:1.1.5"
     const val Orchestrator = "androidx.test:orchestrator:1.4.2"
     const val Rules = "androidx.test:rules:${Versions.AndroidXTest}"
     const val Runner = "androidx.test:runner:${Versions.AndroidXTest}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,7 +16,7 @@ object Dependencies {
     val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KotlinCompiler}"
     const val Ktlint = "org.jlleitschuh.gradle:ktlint-gradle:11.6.1"
     const val BinaryCompatibility = "org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0"
-    const val Dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.5.0"
+    const val Dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.9.10"
   }
 
   const val AppCompat = "androidx.appcompat:appcompat:1.3.1"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,15 +3,15 @@ object Versions {
    * To change this in the IDE, use `systemProp.square.kotlinVersion=x.y.z` in your
    * `~/.gradle/gradle.properties` file.
    */
-  val KotlinCompiler = System.getProperty("square.kotlinVersion") ?: "1.5.21"
+  val KotlinCompiler = System.getProperty("square.kotlinVersion") ?: "1.9.10"
 
-  const val AndroidXTest = "1.4.0"
-  const val Compose = "1.0.1"
+  const val AndroidXTest = "1.5.0"
+  const val Compose = "1.5.3"
 }
 
 object Dependencies {
   object Build {
-    const val Android = "com.android.tools.build:gradle:7.0.0"
+    const val Android = "com.android.tools.build:gradle:8.1.2"
     const val MavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.14.0"
     val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KotlinCompiler}"
     const val Ktlint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
@@ -24,7 +24,7 @@ object Dependencies {
   const val Curtains = "com.squareup.curtains:curtains:1.2.2"
   const val JUnit = "junit:junit:4.13"
   const val Mockito = "org.mockito:mockito-core:3.11.2"
-  const val Robolectric = "org.robolectric:robolectric:4.6.1"
+  const val Robolectric = "org.robolectric:robolectric:4.10.3"
   const val Truth = "com.google.truth:truth:1.1.3"
 
   class Compose(composeVersion: String = Versions.Compose) {
@@ -37,9 +37,9 @@ object Dependencies {
 
   object InstrumentationTests {
     const val Core = "androidx.test:core:${Versions.AndroidXTest}"
-    const val Espresso = "androidx.test.espresso:espresso-core:3.4.0"
+    const val Espresso = "androidx.test.espresso:espresso-core:3.5.1"
     const val JUnit = "androidx.test.ext:junit:1.1.3"
-    const val Orchestrator = "androidx.test:orchestrator:${Versions.AndroidXTest}"
+    const val Orchestrator = "androidx.test:orchestrator:1.4.2"
     const val Rules = "androidx.test:rules:${Versions.AndroidXTest}"
     const val Runner = "androidx.test:runner:${Versions.AndroidXTest}"
   }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -14,7 +14,7 @@ object Dependencies {
     const val Android = "com.android.tools.build:gradle:8.1.2"
     const val MavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.14.0"
     val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KotlinCompiler}"
-    const val Ktlint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
+    const val Ktlint = "org.jlleitschuh.gradle:ktlint-gradle:11.6.1"
     const val BinaryCompatibility = "org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0"
     const val Dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.5.0"
   }

--- a/compose-tests/build.gradle.kts
+++ b/compose-tests/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-  compileSdk = 30
+  compileSdk = 31
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -15,7 +15,7 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 30
+    targetSdk = 31
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -28,12 +28,14 @@ android {
     kotlinCompilerExtensionVersion = Versions.Compose
   }
 
-  packagingOptions {
+  packaging {
     resources.excludes += listOf(
       "META-INF/AL2.0",
       "META-INF/LGPL2.1",
     )
   }
+  namespace = "com.squareup.radiography.test.compose.empty"
+  testNamespace = "com.squareup.radiography.test.compose"
 }
 
 tasks.withType<KotlinCompile> {

--- a/compose-tests/build.gradle.kts
+++ b/compose-tests/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-  compileSdk = 31
+  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -15,7 +15,7 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 31
+    targetSdk = 34
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 

--- a/compose-tests/src/androidTest/AndroidManifest.xml
+++ b/compose-tests/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.squareup.radiography.test.compose">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
     <activity android:name="androidx.activity.ComponentActivity" />

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -597,14 +597,14 @@ class ComposeUiTest {
       """
       |CompositionLocalProvider:
       |${BLANK}CompositionLocalProvider { test-tag:"parent" }
-      |${BLANK}╰─LazyColumn { test-tag:"list", vertical-scroll-axis-range:"ScrollAxisRange(value=0.0, maxValue=Infinity)" }
+      |${BLANK}╰─LazyColumn { test-tag:"list", vertical-scroll-axis-range:"ScrollAxisRange(value=0.0, maxValue=0.0)" }
       |${BLANK}  ├─<subcomposition of LazyColumn>
-      |${BLANK}  │ ╰─SaveableStateProvider { test-tag:"child:1" }
+      |${BLANK}  │ ╰─SkippableItem { test-tag:"child:1" }
       |${BLANK}  ├─<subcomposition of LazyColumn>
-      |${BLANK}  │ ├─SaveableStateProvider { test-tag:"child:2" }
-      |${BLANK}  │ ╰─SaveableStateProvider { test-tag:"child:2 (even)" }
+      |${BLANK}  │ ├─SkippableItem { test-tag:"child:2" }
+      |${BLANK}  │ ╰─SkippableItem { test-tag:"child:2 (even)" }
       |${BLANK}  ╰─<subcomposition of LazyColumn>
-      |${BLANK}    ╰─SaveableStateProvider { test-tag:"child:3" }
+      |${BLANK}    ╰─SkippableItem { test-tag:"child:3" }
       |
       """.trimMargin()
     )

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -44,7 +44,6 @@ class ComposeViewTest {
     assertThat(textComposable.children.asIterable()).isEmpty()
   }
 
-  // Needs fixing
   @Test fun composeView_children_includes_AndroidView() {
     composeRule.setContentWithExplicitRoot {
       Column {

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -44,6 +44,7 @@ class ComposeViewTest {
     assertThat(textComposable.children.asIterable()).isEmpty()
   }
 
+  // Needs fixing
   @Test fun composeView_children_includes_AndroidView() {
     composeRule.setContentWithExplicitRoot {
       Column {

--- a/compose-tests/src/main/AndroidManifest.xml
+++ b/compose-tests/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.squareup.radiography.test.compose.empty" />
+<manifest />

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -2,9 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("com.android.library")
-  // Older version of Compose requires an older version of Kotlin.
   kotlin("android")
-//  kotlin("android") version "1.5.21"
 }
 
 /**
@@ -58,7 +56,7 @@ tasks.withType<KotlinCompile> {
 dependencies {
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
-  androidTestImplementation(Dependencies.Compose().Activity("1.3.1"))
+  androidTestImplementation(Dependencies.Compose().Activity("1.3.0-alpha02"))
   androidTestImplementation(Dependencies.Compose(oldComposeVersion).Material)
   androidTestImplementation(Dependencies.Compose(oldComposeVersion).Testing)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -14,7 +14,7 @@ val oldComposeVersion = "1.0.1"
 val oldComposeCompiler = "1.5.21"
 
 android {
-  compileSdk = 30
+  compileSdk = 31
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -23,7 +23,7 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 30
+    targetSdk = 31
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -36,12 +36,14 @@ android {
     kotlinCompilerExtensionVersion = oldComposeVersion
   }
 
-  packagingOptions {
+  packaging {
     resources.excludes += listOf(
       "META-INF/AL2.0",
       "META-INF/LGPL2.1"
     )
   }
+    namespace = "com.squareup.radiography.test.compose.unsupported.empty"
+    testNamespace = "com.squareup.radiography.test.compose.unsupported"
 }
 
 tasks.withType<KotlinCompile> {

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
  * Allows using a different version of Compose to validate that we degrade gracefully on apps
  * built with unsupported Compose versions.
  */
-val oldComposeVersion = "1.0.1"
+val oldComposeVersion = "1.3.0"
 
 android {
   compileSdk = 34
@@ -31,7 +31,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = oldComposeVersion
+    kotlinCompilerExtensionVersion = Versions.Compose
   }
 
   packaging {

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -2,7 +2,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("com.android.library")
+  // Older version of Compose requires an older version of Kotlin.
   kotlin("android")
+//  kotlin("android") version "1.5.21"
 }
 
 /**
@@ -10,11 +12,9 @@ plugins {
  * built with unsupported Compose versions.
  */
 val oldComposeVersion = "1.0.1"
-// Older version of Compose requires an older version of Kotlin.
-val oldComposeCompiler = "1.5.21"
 
 android {
-  compileSdk = 31
+  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -23,7 +23,7 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 31
+    targetSdk = 34
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -58,10 +58,11 @@ tasks.withType<KotlinCompile> {
 dependencies {
   androidTestImplementation(project(":radiography"))
   androidTestImplementation(Dependencies.AppCompat)
-  androidTestImplementation(Dependencies.Compose().Activity("1.3.0-alpha02"))
+  androidTestImplementation(Dependencies.Compose().Activity("1.3.1"))
   androidTestImplementation(Dependencies.Compose(oldComposeVersion).Material)
   androidTestImplementation(Dependencies.Compose(oldComposeVersion).Testing)
   androidTestImplementation(Dependencies.InstrumentationTests.Rules)
+  androidTestImplementation(Dependencies.InstrumentationTests.JUnit)
   androidTestImplementation(Dependencies.InstrumentationTests.Runner)
   androidTestImplementation(Dependencies.Truth)
 }

--- a/compose-unsupported-tests/src/androidTest/AndroidManifest.xml
+++ b/compose-unsupported-tests/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.squareup.radiography.test.compose.unsupported">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
     <activity android:name="androidx.activity.ComponentActivity" />

--- a/compose-unsupported-tests/src/main/AndroidManifest.xml
+++ b/compose-unsupported-tests/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.squareup.radiography.test.compose.unsupported.empty" />
+<manifest />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -8,6 +8,7 @@ public abstract interface annotation class radiography/ExperimentalRadiographyCo
 
 public final class radiography/Radiography {
 	public static final field INSTANCE Lradiography/Radiography;
+	public final synthetic fun renderScannableViewTree$radiography_release (Ljava/lang/StringBuilder;Lradiography/ScannableView;Ljava/util/List;Lradiography/ViewFilter;)V
 	public static final fun scan ()Ljava/lang/String;
 	public static final fun scan (Lradiography/ScanScope;)Ljava/lang/String;
 	public static final fun scan (Lradiography/ScanScope;Ljava/util/List;)Ljava/lang/String;
@@ -21,6 +22,7 @@ public abstract interface class radiography/ScanScope {
 
 public final class radiography/ScanScopes {
 	public static final field AllWindowsScope Lradiography/ScanScope;
+	public static final field EmptyScope Lradiography/ScanScope;
 	public static final field FocusedWindowScope Lradiography/ScanScope;
 	public static final field INSTANCE Lradiography/ScanScopes;
 	public static final fun composeTestTagScope (Ljava/lang/String;)Lradiography/ScanScope;
@@ -58,6 +60,10 @@ public final class radiography/ScannableView$ComposeView : radiography/Scannable
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class radiography/ScannableViewKt {
+	public static final fun toScannableView (Lradiography/internal/ComposeLayoutInfo;)Lradiography/ScannableView;
+}
+
 public abstract interface class radiography/ViewFilter {
 	public abstract fun matches (Lradiography/ScannableView;)Z
 }
@@ -67,6 +73,7 @@ public final class radiography/ViewFilters {
 	public static final field NoFilter Lradiography/ViewFilter;
 	public static final fun and (Lradiography/ViewFilter;Lradiography/ViewFilter;)Lradiography/ViewFilter;
 	public static final fun androidViewFilterFor (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lradiography/ViewFilter;
+	public final synthetic fun androidViewFilterFor (Lkotlin/jvm/functions/Function1;)Lradiography/ViewFilter;
 	public static final fun skipComposeTestTagsFilter ([Ljava/lang/String;)Lradiography/ViewFilter;
 	public static final fun skipIdsViewFilter ([I)Lradiography/ViewFilter;
 }
@@ -82,6 +89,10 @@ public final class radiography/ViewStateRenderers {
 	public static final field INSTANCE Lradiography/ViewStateRenderers;
 	public static final field ViewRenderer Lradiography/ViewStateRenderer;
 	public static final fun androidViewStateRendererFor (Ljava/lang/Class;Lkotlin/jvm/functions/Function2;)Lradiography/ViewStateRenderer;
+	public final synthetic fun androidViewStateRendererFor (Lkotlin/jvm/functions/Function2;)Lradiography/ViewStateRenderer;
+	public final fun appendTextValue$radiography_release (Lradiography/AttributeAppendable;Ljava/lang/String;Ljava/lang/CharSequence;ZI)V
+	public static final synthetic fun composeTextRenderer$radiography_release (ZI)Lradiography/ViewStateRenderer;
+	public static synthetic fun composeTextRenderer$radiography_release$default (ZIILjava/lang/Object;)Lradiography/ViewStateRenderer;
 	public static final fun textViewRenderer ()Lradiography/ViewStateRenderer;
 	public static final fun textViewRenderer (Z)Lradiography/ViewStateRenderer;
 	public static final fun textViewRenderer (ZI)Lradiography/ViewStateRenderer;
@@ -91,5 +102,81 @@ public final class radiography/ViewStateRenderers {
 public final class radiography/ViewsKt {
 	public static final synthetic fun scan (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;)Ljava/lang/String;
 	public static synthetic fun scan$default (Landroid/view/View;Ljava/util/List;Lradiography/ViewFilter;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract class radiography/internal/ComposeLayoutInfo {
+}
+
+public final class radiography/internal/ComposeLayoutInfo$AndroidViewInfo : radiography/internal/ComposeLayoutInfo {
+	public fun <init> (Landroid/view/View;)V
+	public final fun component1 ()Landroid/view/View;
+	public final fun copy (Landroid/view/View;)Lradiography/internal/ComposeLayoutInfo$AndroidViewInfo;
+	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$AndroidViewInfo;Landroid/view/View;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$AndroidViewInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getView ()Landroid/view/View;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class radiography/internal/ComposeLayoutInfo$LayoutNodeInfo : radiography/internal/ComposeLayoutInfo {
+	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Landroidx/compose/ui/unit/IntRect;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lkotlin/sequences/Sequence;
+	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
+	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Landroidx/compose/ui/unit/IntRect;
+	public final fun getChildren ()Lkotlin/sequences/Sequence;
+	public final fun getModifiers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class radiography/internal/ComposeLayoutInfo$SubcompositionInfo : radiography/internal/ComposeLayoutInfo {
+	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Landroidx/compose/ui/unit/IntRect;
+	public final fun component3 ()Lkotlin/sequences/Sequence;
+	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;)Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;
+	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Landroidx/compose/ui/unit/IntRect;
+	public final fun getChildren ()Lkotlin/sequences/Sequence;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class radiography/internal/ComposeLayoutInfoKt {
+	public static final fun getLayoutInfos (Landroidx/compose/ui/tooling/data/Group;)Lkotlin/sequences/Sequence;
+}
+
+public final class radiography/internal/ComposeViewsKt {
+	public static final field COMPOSE_UNSUPPORTED_MESSAGE Ljava/lang/String;
+	public static final fun composeRenderingError (Ljava/lang/LinkageError;)Lradiography/ScannableView;
+	public static final fun getComposeScannableViews (Landroid/view/View;)Lkotlin/Pair;
+	public static final fun getMightBeComposeView (Landroid/view/View;)Z
+	public static final fun isComposeAvailable ()Z
+}
+
+public final class radiography/internal/CompositionContextsKt {
+	public static final fun getCompositionContexts (Landroidx/compose/ui/tooling/data/Group;)Lkotlin/sequences/Sequence;
+	public static final fun tryGetComposers (Landroidx/compose/runtime/CompositionContext;)Ljava/lang/Iterable;
+}
+
+public final class radiography/internal/RenderTreeStringKt {
+	public static final fun renderTreeString (Ljava/lang/StringBuilder;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class radiography/internal/SemanticsKt {
+	public static final fun findTestTags (Lradiography/ScannableView$ComposeView;)Lkotlin/sequences/Sequence;
+}
+
+public final class radiography/internal/StringsKt {
+	public static final fun ellipsize (Ljava/lang/CharSequence;I)Ljava/lang/CharSequence;
+	public static final fun formatPixelDimensions (II)Ljava/lang/String;
 }
 

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -51,11 +51,13 @@ public final class radiography/ScannableView$ChildRenderingError : radiography/S
 }
 
 public final class radiography/ScannableView$ComposeView : radiography/ScannableView {
-	public fun <init> (Ljava/lang/String;IILjava/util/List;Lkotlin/sequences/Sequence;)V
+	public fun <init> (Ljava/lang/String;IILjava/util/List;Ljava/util/List;Lkotlin/sequences/Sequence;)V
 	public fun getChildren ()Lkotlin/sequences/Sequence;
 	public fun getDisplayName ()Ljava/lang/String;
 	public final fun getHeight ()I
 	public final fun getModifiers ()Ljava/util/List;
+	public final fun getSemanticsConfigurations ()Ljava/util/List;
+	public final fun getSemanticsNodes ()Ljava/util/List;
 	public final fun getWidth ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -119,18 +121,20 @@ public final class radiography/internal/ComposeLayoutInfo$AndroidViewInfo : radi
 }
 
 public final class radiography/internal/ComposeLayoutInfo$LayoutNodeInfo : radiography/internal/ComposeLayoutInfo {
-	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;)V
+	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Landroidx/compose/ui/unit/IntRect;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Lkotlin/sequences/Sequence;
-	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
-	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
+	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Landroidx/compose/ui/unit/IntRect;
 	public final fun getChildren ()Lkotlin/sequences/Sequence;
 	public final fun getModifiers ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getSemanticsNodes ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -151,7 +155,8 @@ public final class radiography/internal/ComposeLayoutInfo$SubcompositionInfo : r
 }
 
 public final class radiography/internal/ComposeLayoutInfoKt {
-	public static final fun getLayoutInfos (Landroidx/compose/ui/tooling/data/Group;)Lkotlin/sequences/Sequence;
+	public static final fun computeLayoutInfos (Landroidx/compose/ui/tooling/data/Group;Ljava/lang/String;Landroidx/compose/ui/semantics/SemanticsOwner;)Lkotlin/sequences/Sequence;
+	public static synthetic fun computeLayoutInfos$default (Landroidx/compose/ui/tooling/data/Group;Ljava/lang/String;Landroidx/compose/ui/semantics/SemanticsOwner;ILjava/lang/Object;)Lkotlin/sequences/Sequence;
 }
 
 public final class radiography/internal/ComposeViewsKt {

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 android {
-  compileSdk = 30
+  compileSdk = 31
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -31,7 +31,7 @@ android {
 
   defaultConfig {
     minSdk = 17
-    targetSdk = 30
+    targetSdk = 31
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -42,6 +42,8 @@ android {
   testOptions {
     execution = "ANDROIDX_TEST_ORCHESTRATOR"
   }
+    namespace = "com.squareup.radiography"
+    testNamespace = "com.squareup.radiography.test"
 }
 
 tasks.withType<KotlinCompile> {

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 android {
-  compileSdk = 31
+  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -31,7 +31,7 @@ android {
 
   defaultConfig {
     minSdk = 17
-    targetSdk = 31
+    targetSdk = 34
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 

--- a/radiography/src/androidTest/AndroidManifest.xml
+++ b/radiography/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.squareup.radiography.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <!--
    Workaround required for running tests on API 30 devices.

--- a/radiography/src/main/AndroidManifest.xml
+++ b/radiography/src/main/AndroidManifest.xml
@@ -13,4 +13,4 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<manifest package="com.squareup.radiography"/>
+<manifest />

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -3,6 +3,9 @@ package radiography
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsModifier
+import androidx.compose.ui.semantics.SemanticsNode
 import radiography.ScannableView.AndroidView
 import radiography.ScannableView.ComposeView
 import radiography.internal.ComposeLayoutInfo
@@ -20,87 +23,99 @@ import radiography.internal.mightBeComposeView
  */
 public sealed class ScannableView {
 
-  /** The string that be used to identify the type of the view in the rendered output. */
-  public abstract val displayName: String
+    /** The string that be used to identify the type of the view in the rendered output. */
+    public abstract val displayName: String
 
-  /** The children of this view. */
-  public abstract val children: Sequence<ScannableView>
+    /** The children of this view. */
+    public abstract val children: Sequence<ScannableView>
 
-  public class AndroidView(public val view: View) : ScannableView() {
-    override val displayName: String get() = view::class.java.simpleName
-    override val children: Sequence<ScannableView> = view.scannableChildren()
+    public class AndroidView(public val view: View) : ScannableView() {
+        override val displayName: String get() = view::class.java.simpleName
+        override val children: Sequence<ScannableView> = view.scannableChildren()
 
-    override fun toString(): String = "${AndroidView::class.java.simpleName}($displayName)"
-  }
+        override fun toString(): String = "${AndroidView::class.java.simpleName}($displayName)"
+    }
 
-  /**
-   * Represents a group of Composables that make up a logical "view".
-   *
-   * @param modifiers The list of [Modifier]s that are currently applied to the Composable.
-   */
-  @ExperimentalRadiographyComposeApi
-  public class ComposeView(
-    override val displayName: String,
-    public val width: Int,
-    public val height: Int,
-    public val modifiers: List<Modifier>,
-    override val children: Sequence<ScannableView>
-  ) : ScannableView() {
-    override fun toString(): String = "${ComposeView::class.java.simpleName}($displayName)"
-  }
+    /**
+     * Represents a group of Composables that make up a logical "view".
+     *
+     * @param modifiers The list of [Modifier]s that are currently applied to the Composable.
+     */
+    @ExperimentalRadiographyComposeApi
+    public class ComposeView(
+        override val displayName: String,
+        public val width: Int,
+        public val height: Int,
+        public val modifiers: List<Modifier>,
+        public val semanticsNodes: List<SemanticsNode>,
+        override val children: Sequence<ScannableView>,
+    ) : ScannableView() {
+        override fun toString(): String = "${ComposeView::class.java.simpleName}($displayName)"
 
-  /**
-   * Indicates that an exception was thrown while rendering part of the tree.
-   * This should be used for non-fatal errors, when the rest of the tree should still be processed.
-   *
-   * By default, exceptions thrown during rendering will abort the entire rendering process, and
-   * return the error message along with any portion of the tree that was rendered before the
-   * exception was thrown.
-   */
-  public class ChildRenderingError(private val message: String) : ScannableView() {
-    override val displayName: String get() = message
-    override val children: Sequence<ScannableView> get() = emptySequence()
-  }
+        public val semanticsConfigurations: List<SemanticsConfiguration>
+            get() {
+                return semanticsNodes.map { it.config }.ifEmpty { null }
+                    ?: modifiers
+                        .filterIsInstance<SemanticsModifier>()
+                        .map { it.semanticsConfiguration }
+            }
+    }
+
+    /**
+     * Indicates that an exception was thrown while rendering part of the tree.
+     * This should be used for non-fatal errors, when the rest of the tree should still be processed.
+     *
+     * By default, exceptions thrown during rendering will abort the entire rendering process, and
+     * return the error message along with any portion of the tree that was rendered before the
+     * exception was thrown.
+     */
+    public class ChildRenderingError(private val message: String) : ScannableView() {
+        override val displayName: String get() = message
+        override val children: Sequence<ScannableView> get() = emptySequence()
+    }
 }
 
-@OptIn(ExperimentalRadiographyComposeApi::class)
 private fun View.scannableChildren(): Sequence<ScannableView> = sequence {
-  if (mightBeComposeView) {
-    val (composableViews, parsedComposables) = getComposeScannableViews(this@scannableChildren)
-    // If unsuccessful, the list will contain a RenderError, so yield it anyway.
-    yieldAll(composableViews)
-    if (parsedComposables) {
-      // Don't visit children ourselves, the compose renderer will have done that.
-      return@sequence
+    if (mightBeComposeView) {
+        val (composableViews, parsedComposables) = getComposeScannableViews(this@scannableChildren)
+        // If unsuccessful, the list will contain a RenderError, so yield it anyway.
+        yieldAll(composableViews)
+        if (parsedComposables) {
+            // Don't visit children ourselves, the compose renderer will have done that.
+            return@sequence
+        }
     }
-  }
 
-  if (this@scannableChildren !is ViewGroup) return@sequence
+    if (this@scannableChildren !is ViewGroup) return@sequence
 
-  for (i in 0 until childCount) {
-    // Child may be null, if children were removed by another thread after we captured the child
-    // count. getChildAt returns null for invalid indices, it doesn't throw.
-    val view = getChildAt(i) ?: continue
-    yield(AndroidView(view))
-  }
+    for (i in 0 until childCount) {
+        // Child may be null, if children were removed by another thread after we captured the child
+        // count. getChildAt returns null for invalid indices, it doesn't throw.
+        val view = getChildAt(i) ?: continue
+        yield(AndroidView(view))
+    }
 }
 
 @OptIn(ExperimentalRadiographyComposeApi::class)
 internal fun ComposeLayoutInfo.toScannableView(): ScannableView = when (val layoutInfo = this) {
-  is LayoutNodeInfo -> ComposeView(
-    displayName = layoutInfo.name,
-    // Can't use width and height properties because we're not targeting 1.8 bytecode.
-    width = layoutInfo.bounds.run { right - left },
-    height = layoutInfo.bounds.run { bottom - top },
-    modifiers = layoutInfo.modifiers,
-    children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView)
-  )
-  is SubcompositionInfo -> ComposeView(
-    displayName = layoutInfo.name,
-    width = layoutInfo.bounds.run { right - left },
-    height = layoutInfo.bounds.run { bottom - top },
-    children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView),
-    modifiers = emptyList()
-  )
-  is AndroidViewInfo -> AndroidView(layoutInfo.view)
+    is LayoutNodeInfo -> ComposeView(
+        displayName = layoutInfo.name,
+        // Can't use width and height properties because we're not targeting 1.8 bytecode.
+        width = layoutInfo.bounds.run { right - left },
+        height = layoutInfo.bounds.run { bottom - top },
+        modifiers = layoutInfo.modifiers,
+        semanticsNodes = layoutInfo.semanticsNodes,
+        children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView)
+    )
+
+    is SubcompositionInfo -> ComposeView(
+        displayName = layoutInfo.name,
+        width = layoutInfo.bounds.run { right - left },
+        height = layoutInfo.bounds.run { bottom - top },
+        modifiers = emptyList(),
+        semanticsNodes = emptyList(),
+        children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView),
+    )
+
+    is AndroidViewInfo -> AndroidView(layoutInfo.view)
 }

--- a/radiography/src/main/java/radiography/ScannableView.kt
+++ b/radiography/src/main/java/radiography/ScannableView.kt
@@ -23,99 +23,99 @@ import radiography.internal.mightBeComposeView
  */
 public sealed class ScannableView {
 
-    /** The string that be used to identify the type of the view in the rendered output. */
-    public abstract val displayName: String
+  /** The string that be used to identify the type of the view in the rendered output. */
+  public abstract val displayName: String
 
-    /** The children of this view. */
-    public abstract val children: Sequence<ScannableView>
+  /** The children of this view. */
+  public abstract val children: Sequence<ScannableView>
 
-    public class AndroidView(public val view: View) : ScannableView() {
-        override val displayName: String get() = view::class.java.simpleName
-        override val children: Sequence<ScannableView> = view.scannableChildren()
+  public class AndroidView(public val view: View) : ScannableView() {
+    override val displayName: String get() = view::class.java.simpleName
+    override val children: Sequence<ScannableView> = view.scannableChildren()
 
-        override fun toString(): String = "${AndroidView::class.java.simpleName}($displayName)"
-    }
+    override fun toString(): String = "${AndroidView::class.java.simpleName}($displayName)"
+  }
 
-    /**
-     * Represents a group of Composables that make up a logical "view".
-     *
-     * @param modifiers The list of [Modifier]s that are currently applied to the Composable.
-     */
-    @ExperimentalRadiographyComposeApi
-    public class ComposeView(
-        override val displayName: String,
-        public val width: Int,
-        public val height: Int,
-        public val modifiers: List<Modifier>,
-        public val semanticsNodes: List<SemanticsNode>,
-        override val children: Sequence<ScannableView>,
-    ) : ScannableView() {
-        override fun toString(): String = "${ComposeView::class.java.simpleName}($displayName)"
+  /**
+   * Represents a group of Composables that make up a logical "view".
+   *
+   * @param modifiers The list of [Modifier]s that are currently applied to the Composable.
+   */
+  @ExperimentalRadiographyComposeApi
+  public class ComposeView(
+    override val displayName: String,
+    public val width: Int,
+    public val height: Int,
+    public val modifiers: List<Modifier>,
+    public val semanticsNodes: List<SemanticsNode>,
+    override val children: Sequence<ScannableView>,
+  ) : ScannableView() {
+    override fun toString(): String = "${ComposeView::class.java.simpleName}($displayName)"
 
-        public val semanticsConfigurations: List<SemanticsConfiguration>
-            get() {
-                return semanticsNodes.map { it.config }.ifEmpty { null }
-                    ?: modifiers
-                        .filterIsInstance<SemanticsModifier>()
-                        .map { it.semanticsConfiguration }
-            }
-    }
+    public val semanticsConfigurations: List<SemanticsConfiguration>
+      get() {
+        return semanticsNodes.map { it.config }.ifEmpty { null }
+          ?: modifiers
+            .filterIsInstance<SemanticsModifier>()
+            .map { it.semanticsConfiguration }
+      }
+  }
 
-    /**
-     * Indicates that an exception was thrown while rendering part of the tree.
-     * This should be used for non-fatal errors, when the rest of the tree should still be processed.
-     *
-     * By default, exceptions thrown during rendering will abort the entire rendering process, and
-     * return the error message along with any portion of the tree that was rendered before the
-     * exception was thrown.
-     */
-    public class ChildRenderingError(private val message: String) : ScannableView() {
-        override val displayName: String get() = message
-        override val children: Sequence<ScannableView> get() = emptySequence()
-    }
+  /**
+   * Indicates that an exception was thrown while rendering part of the tree.
+   * This should be used for non-fatal errors, when the rest of the tree should still be processed.
+   *
+   * By default, exceptions thrown during rendering will abort the entire rendering process, and
+   * return the error message along with any portion of the tree that was rendered before the
+   * exception was thrown.
+   */
+  public class ChildRenderingError(private val message: String) : ScannableView() {
+    override val displayName: String get() = message
+    override val children: Sequence<ScannableView> get() = emptySequence()
+  }
 }
 
 private fun View.scannableChildren(): Sequence<ScannableView> = sequence {
-    if (mightBeComposeView) {
-        val (composableViews, parsedComposables) = getComposeScannableViews(this@scannableChildren)
-        // If unsuccessful, the list will contain a RenderError, so yield it anyway.
-        yieldAll(composableViews)
-        if (parsedComposables) {
-            // Don't visit children ourselves, the compose renderer will have done that.
-            return@sequence
-        }
+  if (mightBeComposeView) {
+    val (composableViews, parsedComposables) = getComposeScannableViews(this@scannableChildren)
+    // If unsuccessful, the list will contain a RenderError, so yield it anyway.
+    yieldAll(composableViews)
+    if (parsedComposables) {
+      // Don't visit children ourselves, the compose renderer will have done that.
+      return@sequence
     }
+  }
 
-    if (this@scannableChildren !is ViewGroup) return@sequence
+  if (this@scannableChildren !is ViewGroup) return@sequence
 
-    for (i in 0 until childCount) {
-        // Child may be null, if children were removed by another thread after we captured the child
-        // count. getChildAt returns null for invalid indices, it doesn't throw.
-        val view = getChildAt(i) ?: continue
-        yield(AndroidView(view))
-    }
+  for (i in 0 until childCount) {
+    // Child may be null, if children were removed by another thread after we captured the child
+    // count. getChildAt returns null for invalid indices, it doesn't throw.
+    val view = getChildAt(i) ?: continue
+    yield(AndroidView(view))
+  }
 }
 
 @OptIn(ExperimentalRadiographyComposeApi::class)
 internal fun ComposeLayoutInfo.toScannableView(): ScannableView = when (val layoutInfo = this) {
-    is LayoutNodeInfo -> ComposeView(
-        displayName = layoutInfo.name,
-        // Can't use width and height properties because we're not targeting 1.8 bytecode.
-        width = layoutInfo.bounds.run { right - left },
-        height = layoutInfo.bounds.run { bottom - top },
-        modifiers = layoutInfo.modifiers,
-        semanticsNodes = layoutInfo.semanticsNodes,
-        children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView)
-    )
+  is LayoutNodeInfo -> ComposeView(
+    displayName = layoutInfo.name,
+    // Can't use width and height properties because we're not targeting 1.8 bytecode.
+    width = layoutInfo.bounds.run { right - left },
+    height = layoutInfo.bounds.run { bottom - top },
+    modifiers = layoutInfo.modifiers,
+    semanticsNodes = layoutInfo.semanticsNodes,
+    children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView)
+  )
 
-    is SubcompositionInfo -> ComposeView(
-        displayName = layoutInfo.name,
-        width = layoutInfo.bounds.run { right - left },
-        height = layoutInfo.bounds.run { bottom - top },
-        modifiers = emptyList(),
-        semanticsNodes = emptyList(),
-        children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView),
-    )
+  is SubcompositionInfo -> ComposeView(
+    displayName = layoutInfo.name,
+    width = layoutInfo.bounds.run { right - left },
+    height = layoutInfo.bounds.run { bottom - top },
+    modifiers = emptyList(),
+    semanticsNodes = emptyList(),
+    children = layoutInfo.children.map(ComposeLayoutInfo::toScannableView),
+  )
 
-    is AndroidViewInfo -> AndroidView(layoutInfo.view)
+  is AndroidViewInfo -> AndroidView(layoutInfo.view)
 }

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -214,7 +214,6 @@ public object ViewStateRenderers {
   ): ViewStateRenderer = if (!isComposeAvailable) NoRenderer else ViewStateRenderer { view ->
     val semantics = (view as? ComposeView)?.semanticsConfigurations ?: emptyList()
 
-
     semantics.mapNotNull { it.getOrNull(Text)?.joinToString() }
       .takeUnless { it.isEmpty() }
       ?.joinToString(separator = " ")

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -212,19 +212,17 @@ public object ViewStateRenderers {
     renderTextValue: Boolean = false,
     textValueMaxLength: Int = Int.MAX_VALUE
   ): ViewStateRenderer = if (!isComposeAvailable) NoRenderer else ViewStateRenderer { view ->
-    val semantics = (view as? ComposeView)
-      ?.modifiers
-      ?.filterIsInstance<SemanticsModifier>()
-      ?: return@ViewStateRenderer
+    val semantics = (view as? ComposeView)?.semanticsConfigurations ?: emptyList()
 
-    semantics.mapNotNull { it.semanticsConfiguration.getOrNull(Text)?.joinToString() }
+
+    semantics.mapNotNull { it.getOrNull(Text)?.joinToString() }
       .takeUnless { it.isEmpty() }
       ?.joinToString(separator = " ")
       ?.also {
         appendTextValue(label = "text", it, renderTextValue, textValueMaxLength)
       }
 
-    semantics.mapNotNull { it.semanticsConfiguration.getOrNull(EditableText)?.text }
+    semantics.mapNotNull { it.getOrNull(EditableText)?.text }
       .takeUnless { it.isEmpty() }
       ?.joinToString(separator = " ")
       ?.also {

--- a/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
@@ -65,6 +65,10 @@ internal sealed class ComposeLayoutInfo {
  */
 internal fun Group.computeLayoutInfos(
   parentName: String = "",
+  /**
+   * The semantics owner for this Group. This is used to look up the semantics nodes for each
+   * layout node.
+   */
   semanticsOwner: SemanticsOwner? = null,
 ): Sequence<ComposeLayoutInfo> {
   val name = parentName.ifBlank { this.name }.orEmpty()

--- a/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
@@ -100,7 +100,7 @@ internal fun Group.computeLayoutInfos(
     name = name,
     bounds = box,
     modifiers = modifierInfo.map { it.modifier },
-    semanticsNodes  = semanticsNodes,
+    semanticsNodes = semanticsNodes,
     children = children + irregularChildren,
   )
   return sequenceOf(layoutInfo)

--- a/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeLayoutInfo.kt
@@ -4,7 +4,9 @@ package radiography.internal
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.InteroperableComposeUiNode
 import androidx.compose.ui.node.Ref
 import androidx.compose.ui.tooling.data.CallGroup
 import androidx.compose.ui.tooling.data.Group
@@ -125,13 +127,13 @@ private fun Group.subComposedChildren(name: String): Sequence<SubcompositionInfo
  * view, and it would be reported by this function. That would almost certainly be a code smell for
  * a number of reasons though, so we don't try to ignore those cases.
  */
-private fun Group.androidViewChildren(): List<AndroidViewInfo> = data.mapNotNull { datum ->
-  (datum as? Ref<*>)
-    ?.value
-    // The concrete type is actually an internal ViewGroup subclass that has all the wiring, but
-    // ultimately it's still just a ViewGroup so this simple check works.
-    ?.let { it as? ViewGroup }
-    ?.let(::AndroidViewInfo)
+@OptIn(InternalComposeUiApi::class)
+private fun Group.androidViewChildren(): List<AndroidViewInfo> {
+  return data.mapNotNull { datum ->
+    (datum as? InteroperableComposeUiNode)
+      ?.getInteropView()
+      ?.let(::AndroidViewInfo)
+  }
 }
 
 /**

--- a/radiography/src/main/java/radiography/internal/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeViews.kt
@@ -4,7 +4,6 @@ import android.util.SparseArray
 import android.view.View
 import androidx.compose.runtime.Composer
 import androidx.compose.runtime.Composition
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.ui.tooling.data.UiToolingDataApi
 import androidx.compose.ui.tooling.data.asTree
 import radiography.ExperimentalRadiographyComposeApi
@@ -125,8 +124,9 @@ private fun tryGetLayoutInfos(composeView: View): Sequence<ComposeLayoutInfo>? {
   // public (eg LayoutNode), so we'd need to use even more (brittle) reflection to do that parsing.
   // That said, once Compose is more stable, it might be worth it to read the slot table directly,
   // since then we could drop the requirement for the Tooling library to be on the classpath.
-  @OptIn(InternalComposeApi::class, UiToolingDataApi::class)
+  @OptIn(UiToolingDataApi::class)
   val rootGroup = composer.compositionData.asTree()
+  @OptIn(UiToolingDataApi::class)
   return rootGroup.layoutInfos
 }
 

--- a/radiography/src/main/java/radiography/internal/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeViews.kt
@@ -65,7 +65,6 @@ private val viewKeyedTagsField: Field? by lazy(PUBLICATION) {
  * unsupported, this function will return a [ChildRenderingError] and false.
  */
 @SuppressLint("VisibleForTests")
-@OptIn(ExperimentalRadiographyComposeApi::class)
 internal fun getComposeScannableViews(composeView: View): Pair<List<ScannableView>, Boolean> {
   var linkageError: LinkageError? = null
 

--- a/radiography/src/main/java/radiography/internal/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeViews.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.compose.runtime.Composer
 import androidx.compose.runtime.Composition
 import androidx.compose.ui.node.RootForTest
-import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.tooling.data.UiToolingDataApi
 import androidx.compose.ui.tooling.data.asTree
 import radiography.ExperimentalRadiographyComposeApi

--- a/radiography/src/main/java/radiography/internal/ComposeViews.kt
+++ b/radiography/src/main/java/radiography/internal/ComposeViews.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composition
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.tooling.data.UiToolingDataApi
 import androidx.compose.ui.tooling.data.asTree
-import radiography.ExperimentalRadiographyComposeApi
 import radiography.ScannableView
 import radiography.ScannableView.ChildRenderingError
 import radiography.ScannableView.ComposeView

--- a/radiography/src/test/java/radiography/RadiographyTest.kt
+++ b/radiography/src/test/java/radiography/RadiographyTest.kt
@@ -141,7 +141,9 @@ internal class RadiographyTest {
     })
     layout.addView(EditText(context))
 
-    val filter = skipIdsViewFilter(42) and ViewFilter { it !is EditText }
+    val filter = skipIdsViewFilter(42) and ViewFilter {
+      (it as? AndroidView)?.view !is EditText
+    }
     layout.scan(viewFilter = filter)
       .also {
         assertThat(it).contains("CheckBox")

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 }
 
 /** Use a separate property for the sample so we can test with different versions easily. */
-val sampleComposeVersion = "1.0.1"
+val sampleComposeVersion = "1.5.3"
 
 android {
-  compileSdk = 30
+  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -18,7 +18,7 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 30
+    targetSdk = 34
     applicationId = "com.squareup.radiography.sample.compose"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -31,10 +31,10 @@ android {
     kotlinCompilerExtensionVersion = sampleComposeVersion
   }
 
-  lint {
-    // Workaround lint bug.
-    disable("InvalidFragmentVersionForActivityResult")
-  }
+//  lint {
+//    // Workaround lint bug.
+//    disable("InvalidFragmentVersionForActivityResult")
+//  }
 
   packagingOptions {
     resources.excludes += listOf(
@@ -42,6 +42,8 @@ android {
       "META-INF/LGPL2.1"
     )
   }
+    namespace = "com.squareup.radiography.sample.compose"
+    testNamespace = "com.squareup.radiography.sample.compose.test"
 }
 
 tasks.withType<KotlinCompile> {

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -31,12 +31,7 @@ android {
     kotlinCompilerExtensionVersion = sampleComposeVersion
   }
 
-//  lint {
-//    // Workaround lint bug.
-//    disable("InvalidFragmentVersionForActivityResult")
-//  }
-
-  packagingOptions {
+  packaging {
     resources.excludes += listOf(
       "META-INF/AL2.0",
       "META-INF/LGPL2.1"

--- a/sample-compose/src/androidTest/AndroidManifest.xml
+++ b/sample-compose/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.squareup.radiography.sample.compose.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
     <activity android:name="androidx.activity.ComponentActivity" />

--- a/sample-compose/src/main/AndroidManifest.xml
+++ b/sample-compose/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.squareup.radiography.sample.compose">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
       android:label="Radiography Compose"
@@ -8,6 +7,7 @@
 
     <activity
         android:name=".MainActivity"
+        android:exported="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/ComposeSampleApp.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import radiography.ExperimentalRadiographyComposeApi
 import radiography.Radiography
 import radiography.ScanScopes.FocusedWindowScope
+import radiography.ScannableView
 import radiography.ViewFilters.skipComposeTestTagsFilter
 import radiography.ViewStateRenderers.CheckableRenderer
 import radiography.ViewStateRenderers.DefaultsIncludingPii
@@ -157,7 +158,8 @@ private fun showSelectionDialog(context: Context) {
     "Focused window and custom filter" to {
       Radiography.scan(
         scanScope = FocusedWindowScope,
-        viewFilter = { view -> view !is LinearLayout }
+        viewFilter = { view ->
+          (view as? ScannableView.AndroidView)?.view !is LinearLayout }
       )
     },
     "Include PII" to {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 android {
-  compileSdk = 31
+  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -29,7 +29,7 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 31
+    targetSdk = 34
     applicationId = "com.squareup.radiography.sample"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 android {
-  compileSdk = 30
+  compileSdk = 31
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -29,10 +29,12 @@ android {
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 30
+    targetSdk = 31
     applicationId = "com.squareup.radiography.sample"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+    namespace = "com.squareup.radiography.sample"
+    testNamespace = "com.squareup.radiography.sample.test"
 }
 
 dependencies {

--- a/sample/src/androidTest/AndroidManifest.xml
+++ b/sample/src/androidTest/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.squareup.radiography.sample.test" />
+<manifest />

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.squareup.radiography.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
       android:label="Radiography"
@@ -22,6 +21,7 @@
 
     <activity
         android:name=".MainActivity"
+        android:exported="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
+++ b/sample/src/main/java/com/squareup/radiography/sample/MainActivity.kt
@@ -11,6 +11,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import radiography.Radiography
 import radiography.ScanScopes.FocusedWindowScope
+import radiography.ScannableView
 import radiography.ViewFilters.skipIdsViewFilter
 import radiography.ViewStateRenderers
 import radiography.ViewStateRenderers.DefaultsIncludingPii
@@ -44,7 +45,9 @@ class MainActivity : Activity() {
       "Focused window and custom filter" to {
         Radiography.scan(
           scanScope = FocusedWindowScope,
-          viewFilter = { it !is LinearLayout }
+          viewFilter = {
+            (it as? ScannableView.AndroidView)?.view !is LinearLayout
+          }
         )
       },
       "Include PII" to {


### PR DESCRIPTION
Fixes https://github.com/square/radiography/issues/153 and https://github.com/square/radiography/issues/156

There are two breaking changes since compose 1.4

The first is that view interop can no longer be gotten from Group data as a Ref. It is now represented with the `InteroperableComposeUiNode` interface (which should be more stable long term).

The larger change is that semantics information can no longer be queried off of Modifiers. Instead, a separate Semantic Node tree, separate from the Layout node tree, is used to store semantic data (https://www.youtube.com/watch?v=BjGX2RftXsU).

I am not 100% sure the best way to access that data, but I was able to do it using standard public APIs which seems like it will be safe and stable long term; I get the SemanticsOwner off of the root compose view, and then match semantics nodes to each layout node via their shared id.

On thing I was not sure about is how the `compose-unsupported-tests` module is suppose to work. From what I gather, it is supposed to apply an older version of compose to test backwards compatibility. However, once I update the kotlin version, the compose version it is trying to use no longer works. What is the guidance on how you want this test module to be set up?