### PR TITLE
Expose call group chain information

### DIFF
--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -135,7 +135,7 @@ class ComposeViewTest {
       .isEqualTo(0)
 
     assertThat(callGroup.displayName)
-      .isEqualTo("Call3")
+      .isEqualTo("Call1")
 
     assertThat(callGroup.semanticsConfigurations.firstNotNullOfOrNull { it[SemanticsProperties.Text] }
       ?.map { it.toString() })
@@ -157,7 +157,7 @@ class ComposeViewTest {
       .hasSize(6)
 
     assertThat(callGroup.callChain.map { it.name })
-      .containsExactly("Call3", "Call2", "Call1", "BasicText", "Layout", "ReusableComposeNode")
+      .containsExactly("Call1", "Call2", "Call3", "BasicText", "Layout", "ReusableComposeNode")
 
     assertThat(callGroup.callChain.map { it.location?.sourceFile })
       .containsExactly(
@@ -173,23 +173,24 @@ class ComposeViewTest {
   private fun renderCallChainUI() {
     composeRule.setContentWithExplicitRoot {
 
+
       @Composable
-      fun Call1() {
+      fun Call3() {
         BasicText(text = "hello")
       }
 
       @Composable
       fun Call2() {
-        Call1()
+        Call3()
       }
 
       @Composable
-      fun Call3() {
+      fun Call1() {
         Call2()
       }
 
       Column {
-        Call3()
+        Call1()
       }
     }
   }

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -8,13 +8,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.Button
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LayoutModifier
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.tooling.data.UiToolingDataApi
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
@@ -34,7 +37,8 @@ class ComposeViewTest {
   @get:Rule
   val composeRule = createAndroidComposeRule<ComponentActivity>()
 
-  @Test fun androidView_children_includes_ComposeViews() {
+  @Test
+  fun androidView_children_includes_ComposeViews() {
     composeRule.setContentWithExplicitRoot {
       BasicText("hello")
     }
@@ -44,7 +48,8 @@ class ComposeViewTest {
     assertThat(textComposable.children.asIterable()).isEmpty()
   }
 
-  @Test fun composeView_children_includes_AndroidView() {
+  @Test
+  fun composeView_children_includes_AndroidView() {
     composeRule.setContentWithExplicitRoot {
       Column {
         androidx.compose.ui.viewinterop.AndroidView(::TextView)
@@ -59,7 +64,8 @@ class ComposeViewTest {
     assertThat(androidViews.count { it.view is TextView }).isEqualTo(1)
   }
 
-  @Test fun composeView_reports_children() {
+  @Test
+  fun composeView_reports_children() {
     composeRule.setContentWithExplicitRoot {
       Column {
         BasicText("hello")
@@ -80,7 +86,8 @@ class ComposeViewTest {
       .isEqualTo(1)
   }
 
-  @Test fun composeView_reports_LayoutModifiers() {
+  @Test
+  fun composeView_reports_LayoutModifiers() {
     composeRule.setContentWithExplicitRoot {
       Box(TestModifier)
     }
@@ -90,7 +97,8 @@ class ComposeViewTest {
     assertThat(boxView.modifiers).contains(TestModifier)
   }
 
-  @Test fun composeView_reports_size() {
+  @Test
+  fun composeView_reports_size() {
     var density: Density? = null
     composeRule.setContentWithExplicitRoot {
       density = LocalDensity.current
@@ -107,6 +115,53 @@ class ComposeViewTest {
       findRootComposeView().allDescendentsDepthFirst.single { it.displayName == "Box" } as ComposeView
     assertThat(boxView.width).isEqualTo(widthPx)
     assertThat(boxView.height).isEqualTo(heightPx)
+  }
+
+  @OptIn(UiToolingDataApi::class)
+  @Test
+  fun composeView_reports_call_chain_info() {
+    composeRule.setContentWithExplicitRoot {
+
+      @Composable
+      fun Call1() {
+        BasicText(text = "hello")
+      }
+
+      @Composable
+      fun Call2() {
+        Call1()
+      }
+
+      @Composable
+      fun Call3() {
+        Call2()
+      }
+
+      Column {
+        Call3()
+      }
+    }
+
+    val columnView = findRootComposeView()
+      .allDescendentsDepthFirst
+      .first { it.displayName == "Column" }
+
+    val columnChildren = columnView.children.toList()
+    assertThat(columnChildren).hasSize(1)
+
+    // Expect that the chain of custom Call functions is collapsed, so that the BasicText
+    // is represented with the name "Call3" but contains the semantic information of the text "hello".
+    val callGroup = columnChildren[0] as ComposeView
+    assertThat(callGroup.children.count()).isEqualTo(0)
+    assertThat(callGroup.displayName).isEqualTo("Call3")
+    assertThat(callGroup.semanticsConfigurations.firstNotNullOfOrNull { it[SemanticsProperties.Text] }?.map { it.toString() })
+      .containsExactly("hello")
+
+    assertThat(callGroup.callChain).hasSize(6)
+    assertThat(callGroup.callChain.map { it.name })
+      .containsExactly("Call3", "Call2", "Call1", "BasicText", "Layout", "ReusableComposeNode")
+    assertThat(callGroup.callChain.map { it.location?.sourceFile })
+      .containsExactly("ComposeViewTest.kt", "ComposeViewTest.kt", "ComposeViewTest.kt", "ComposeViewTest.kt", "BasicText.kt", "Layout.kt")
   }
 
   private object TestModifier : LayoutModifier {

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeViewTest.kt
@@ -173,7 +173,6 @@ class ComposeViewTest {
   private fun renderCallChainUI() {
     composeRule.setContentWithExplicitRoot {
 
-
       @Composable
       fun Call3() {
         BasicText(text = "hello")

--- a/radiography/api/radiography.api
+++ b/radiography/api/radiography.api
@@ -44,6 +44,19 @@ public final class radiography/ScannableView$AndroidView : radiography/Scannable
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class radiography/ScannableView$CallGroupInfo {
+	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/tooling/data/SourceLocation;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Landroidx/compose/ui/tooling/data/SourceLocation;
+	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/tooling/data/SourceLocation;)Lradiography/ScannableView$CallGroupInfo;
+	public static synthetic fun copy$default (Lradiography/ScannableView$CallGroupInfo;Ljava/lang/String;Landroidx/compose/ui/tooling/data/SourceLocation;ILjava/lang/Object;)Lradiography/ScannableView$CallGroupInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocation ()Landroidx/compose/ui/tooling/data/SourceLocation;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class radiography/ScannableView$ChildRenderingError : radiography/ScannableView {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getChildren ()Lkotlin/sequences/Sequence;
@@ -51,7 +64,8 @@ public final class radiography/ScannableView$ChildRenderingError : radiography/S
 }
 
 public final class radiography/ScannableView$ComposeView : radiography/ScannableView {
-	public fun <init> (Ljava/lang/String;IILjava/util/List;Ljava/util/List;Lkotlin/sequences/Sequence;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;IILjava/util/List;Ljava/util/List;Lkotlin/sequences/Sequence;)V
+	public final fun getCallChain ()Ljava/util/List;
 	public fun getChildren ()Lkotlin/sequences/Sequence;
 	public fun getDisplayName ()Ljava/lang/String;
 	public final fun getHeight ()I
@@ -121,16 +135,18 @@ public final class radiography/internal/ComposeLayoutInfo$AndroidViewInfo : radi
 }
 
 public final class radiography/internal/ComposeLayoutInfo$LayoutNodeInfo : radiography/internal/ComposeLayoutInfo {
-	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Landroidx/compose/ui/unit/IntRect;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Lkotlin/sequences/Sequence;
-	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
-	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Landroidx/compose/ui/unit/IntRect;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lkotlin/sequences/Sequence;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
+	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;Ljava/lang/String;Ljava/util/List;Landroidx/compose/ui/unit/IntRect;Ljava/util/List;Lkotlin/sequences/Sequence;Ljava/util/List;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$LayoutNodeInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Landroidx/compose/ui/unit/IntRect;
+	public final fun getCallChain ()Ljava/util/List;
 	public final fun getChildren ()Lkotlin/sequences/Sequence;
 	public final fun getModifiers ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
@@ -140,14 +156,16 @@ public final class radiography/internal/ComposeLayoutInfo$LayoutNodeInfo : radio
 }
 
 public final class radiography/internal/ComposeLayoutInfo$SubcompositionInfo : radiography/internal/ComposeLayoutInfo {
-	public fun <init> (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Landroidx/compose/ui/unit/IntRect;
-	public final fun component3 ()Lkotlin/sequences/Sequence;
-	public final fun copy (Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;)Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;
-	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;Ljava/lang/String;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Landroidx/compose/ui/unit/IntRect;
+	public final fun component4 ()Lkotlin/sequences/Sequence;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;)Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;
+	public static synthetic fun copy$default (Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;Ljava/lang/String;Ljava/util/List;Landroidx/compose/ui/unit/IntRect;Lkotlin/sequences/Sequence;ILjava/lang/Object;)Lradiography/internal/ComposeLayoutInfo$SubcompositionInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Landroidx/compose/ui/unit/IntRect;
+	public final fun getCallChain ()Ljava/util/List;
 	public final fun getChildren ()Lkotlin/sequences/Sequence;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -155,8 +173,8 @@ public final class radiography/internal/ComposeLayoutInfo$SubcompositionInfo : r
 }
 
 public final class radiography/internal/ComposeLayoutInfoKt {
-	public static final fun computeLayoutInfos (Landroidx/compose/ui/tooling/data/Group;Ljava/lang/String;Landroidx/compose/ui/semantics/SemanticsOwner;)Lkotlin/sequences/Sequence;
-	public static synthetic fun computeLayoutInfos$default (Landroidx/compose/ui/tooling/data/Group;Ljava/lang/String;Landroidx/compose/ui/semantics/SemanticsOwner;ILjava/lang/Object;)Lkotlin/sequences/Sequence;
+	public static final fun computeLayoutInfos (Landroidx/compose/ui/tooling/data/Group;Ljava/util/List;Landroidx/compose/ui/semantics/SemanticsOwner;)Lkotlin/sequences/Sequence;
+	public static synthetic fun computeLayoutInfos$default (Landroidx/compose/ui/tooling/data/Group;Ljava/util/List;Landroidx/compose/ui/semantics/SemanticsOwner;ILjava/lang/Object;)Lkotlin/sequences/Sequence;
 }
 
 public final class radiography/internal/ComposeViewsKt {


### PR DESCRIPTION
Our app relies heavily on lots of decomposition within Compose UI in order to organize UI and promote code reuse. However, this means we have lots of Compose functions which are basically wrapper functions and there can be quite a lot of functional nesting like that.

I was quite confused for a while about why these functions didn't show up in the Radiography output, or would show up sporadically. If we have a ui module that exports a compose "component" we want that component name to identify the usage of the component in the radiography output. However, currently this doesn't reliably happen and instead we mostly see more primitive elements show up in the output scan.

The code comment on `computeLayoutInfos` thankfully explains why this happens - only the nodes that emit layouts are represented in the final output, and they inherit the name of the top most call group wrapping them. I can see why this was done, to prevent very verbose chains, but unfortunately it doesn't always result in the best output.

This PR tries to expose more granular information about these call chains so that users can optionally get more insight into what function calls were made. I also included the source location of these function calls so that our tooling can make use of that to make more educated guesses about which functions to surface (eg, if we know its a file in our project, include the call name). To acces this, there is now a property `val callChain: List<CallGroupInfo>` on ComposeView which can be used to get information about all of the call groups wrapping the layout node.

Usage can be seen inside the test: https://github.com/square/radiography/pull/160/files#diff-0a37f7ae94183d0cefb9e8ba89d53a9409011f55230e69ad4300cacee413734eR161

The original behavior in terms of which display names are used is unchanged, and in general there is no impact to existing users. This can be seen in the screenshot of the compose app before and after, and all existing tests pass without changes needed. I did add a test to verify the call chain information is captured correctly.

I hope that this additional capability is welcome, but I am open to suggestions about how to modify the approach to better fit the direction of the library.

Before:
<img width="396" alt="radiography before" src="https://github.com/square/radiography/assets/2739242/7a3093a6-598c-4efa-b0af-911d7f774e57">

After: (note there are no differences)
<img width="389" alt="radiograpy after" src="https://github.com/square/radiography/assets/2739242/27282099-0bbd-4dd9-ba7e-6216adc0276b">
