### PR TITLE
Test drama

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,16 +1,14 @@
 name: Android CI
 
-on:
-  push:
-    branches: [ main ]
-  # Build on all pull requests, regardless of target.
-  pull_request:
+on :
+  pull_request :
+  merge_group :
 
 jobs:
   build:
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on : workflow-kotlin-test-runner-ubuntu-4core
     steps:
     - uses: actions/checkout@v2
     - name: set up JDK 17
@@ -22,7 +20,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macos-latest
+    runs-on : workflow-kotlin-test-runner-ubuntu-4core
     timeout-minutes: 30
     strategy:
       # Allow tests to continue on other devices if they fail on one device.


### PR DESCRIPTION
Two commits so far.

### Get publish consistent with itself

We were installing the old plugin but using the new (`.base`) API.

Without this config failed:

```
Caused by: java.lang.IllegalStateException: The value for this property is final and cannot be changed any further.
        at org.gradle.api.internal.provider.AbstractProperty$FinalizedValue.beforeMutate(AbstractProperty.java:498)
        at org.gradle.api.internal.provider.AbstractProperty.assertCanMutate(AbstractProperty.java:272)
        at org.gradle.api.internal.provider.AbstractProperty.setSupplier(AbstractProperty.java:221)
        at org.gradle.api.internal.provider.DefaultProperty.set(DefaultProperty.java:71)
        at com.vanniktech.maven.publish.MavenPublishBaseExtension.publishToMavenCentral(MavenPublishBaseExtension.kt:55)
        at com.vanniktech.maven.publish.MavenPublishPlugin.apply(MavenPublishPlugin.kt:21)
```

### Add logging to figure out why dialog is not getting focus.

Our SDK 30 tests are failing a lot in `RadiographyUiTest.waitForFocus`, so I've added some logging to give us a little more insight.
