### PR TITLE
Use workflow-kotlin-test-runner-ubuntu-4core to unflake

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,18 +1,16 @@
 name: Android CI
 
-on:
-  push:
-    branches: [ main ]
-  # Build on all pull requests, regardless of target.
-  pull_request:
+on :
+  pull_request :
+  merge_group :
 
 jobs:
   build:
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on : workflow-kotlin-test-runner-ubuntu-4core
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: set up JDK 17
       uses: actions/setup-java@v1
       with:
@@ -22,7 +20,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macos-latest
+    runs-on : workflow-kotlin-test-runner-ubuntu-4core
     timeout-minutes: 30
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
@@ -35,7 +33,16 @@ jobs:
           - 29
           - 30
     steps:
-      - uses: actions/checkout@v2
+      # Setup the runner in the KVM group to enable HW Accleration for the emulator.
+      # see https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+      - name: Enable KVM group perms
+        shell: bash
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Updates our GHA config to take advantage of the runner that was created to unflake Workflow's integration tests, for the same reason.