### PR TITLE
Get publish consistent with itself

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ subprojects {
     configure<MavenPublishBaseExtension> {
       publishToMavenCentral(SonatypeHost.S01)
       signAllPublications()
+      pomFromGradleProperties()
     }
   }
 

--- a/radiography/build.gradle.kts
+++ b/radiography/build.gradle.kts
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   id("com.android.library")
   kotlin("android")
-  id("com.vanniktech.maven.publish")
+  id("com.vanniktech.maven.publish.base")
 }
 
 android {


### PR DESCRIPTION
We were installing the old plugin but using the new (`.base`) API.