### PR TITLE
Support Compose 1.6 and 1.7

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -6,7 +6,9 @@ object Versions {
   val KotlinCompiler = System.getProperty("square.kotlinVersion") ?: "1.9.10"
 
   const val AndroidXTest = "1.5.0"
-  const val Compose = "1.5.3"
+//  const val Compose = "1.5.3"
+//  const val Compose = "1.6.8"
+  const val Compose = "1.7.0-beta05"
 }
 
 object Dependencies {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,6 +9,7 @@ object Versions {
 //  const val Compose = "1.5.3"
 //  const val Compose = "1.6.8"
   const val Compose = "1.7.0-beta05"
+  const val ComposeCompiler = "1.5.3"
 }
 
 object Dependencies {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -6,8 +6,6 @@ object Versions {
   val KotlinCompiler = System.getProperty("square.kotlinVersion") ?: "1.9.10"
 
   const val AndroidXTest = "1.5.0"
-//  const val Compose = "1.5.3"
-//  const val Compose = "1.6.8"
   const val Compose = "1.7.0-beta05"
   const val ComposeCompiler = "1.5.3"
 }

--- a/compose-tests/build.gradle.kts
+++ b/compose-tests/build.gradle.kts
@@ -25,7 +25,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.3"
+    kotlinCompilerExtensionVersion = Versions.ComposeCompiler
   }
 
   packaging {

--- a/compose-tests/build.gradle.kts
+++ b/compose-tests/build.gradle.kts
@@ -25,7 +25,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = Versions.Compose
+    kotlinCompilerExtensionVersion = "1.5.3"
   }
 
   packaging {

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeTestRules.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeTestRules.kt
@@ -2,6 +2,7 @@ package radiography.test.compose
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 
 /**
@@ -14,6 +15,7 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
  */
 fun ComposeContentTestRule.setContentWithExplicitRoot(content: @Composable () -> Unit) {
   setContent {
+    currentComposer.collectParameterInformation()
     Box {
       content()
     }

--- a/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
+++ b/compose-tests/src/androidTest/java/radiography/test/compose/ComposeUiTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -380,6 +381,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesDialog() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         Dialog(onDismissRequest = {}) {
           Box(Modifier.testTag("child"))
@@ -393,8 +396,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}╰─Dialog
       |${BLANK}  ╰─CompositionLocalProvider { DIALOG }
       |${BLANK}    ╰─Box { test-tag:"child" }
@@ -409,6 +412,8 @@ class ComposeUiTest {
     }
 
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         CustomTestDialog {
           Box(Modifier.testTag("child"))
@@ -422,8 +427,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}╰─CustomTestDialog
       |${BLANK}  ╰─CompositionLocalProvider { DIALOG }
       |${BLANK}    ╰─Box { test-tag:"child" }
@@ -434,6 +439,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesSingleSubcomposeLayout_withSingleChild() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         SingleSubcompositionLayout(Modifier.testTag("subcompose-layout")) {
           Box(Modifier.testTag("child"))
@@ -447,8 +454,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}╰─SingleSubcompositionLayout { test-tag:"subcompose-layout" }
       |${BLANK}  ╰─<subcomposition of SingleSubcompositionLayout>
       |${BLANK}    ╰─Box { test-tag:"child" }
@@ -459,6 +466,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesSingleSubcomposeLayout_withMultipleChildren() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         SingleSubcompositionLayout(Modifier.testTag("subcompose-layout")) {
           Box(Modifier.testTag("child1"))
@@ -473,8 +482,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}╰─SingleSubcompositionLayout { test-tag:"subcompose-layout" }
       |${BLANK}  ╰─<subcomposition of SingleSubcompositionLayout>
       |${BLANK}    ├─Box { test-tag:"child1" }
@@ -486,6 +495,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesSingleSubcomposeLayout_withMultipleSubcompositionsAndChildren() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         MultipleSubcompositionLayout(Modifier.testTag("subcompose-layout"),
           firstChildren = {
@@ -505,8 +516,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}╰─MultipleSubcompositionLayout { test-tag:"subcompose-layout" }
       |${BLANK}  ├─<subcomposition of MultipleSubcompositionLayout>
       |${BLANK}  │ ├─Box { test-tag:"child1.1" }
@@ -521,6 +532,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesSiblingSubcomposeLayouts() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         SingleSubcompositionLayout(Modifier.testTag("subcompose-layout1")) {
           Box(Modifier.testTag("child1"))
@@ -537,8 +550,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}├─SingleSubcompositionLayout { test-tag:"subcompose-layout1" }
       |${BLANK}│ ╰─<subcomposition of SingleSubcompositionLayout>
       |${BLANK}│   ╰─Box { test-tag:"child1" }
@@ -552,6 +565,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesWithConstraints() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         BoxWithConstraints(Modifier.testTag("with-constraints")) {
           Box(Modifier.testTag("child"))
@@ -565,8 +580,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
       |${BLANK}╰─BoxWithConstraints { test-tag:"with-constraints" }
       |${BLANK}  ╰─<subcomposition of BoxWithConstraints>
       |${BLANK}    ╰─Box { test-tag:"child" }
@@ -577,6 +592,8 @@ class ComposeUiTest {
 
   @Test fun scanningHandlesLazyLists() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       Box(Modifier.testTag("parent")) {
         LazyColumn(Modifier.testTag("list")) {
           items(listOf(1, 2, 3)) {
@@ -595,9 +612,9 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { test-tag:"parent" }
-      |${BLANK}╰─LazyColumn { test-tag:"list", vertical-scroll-axis-range:"ScrollAxisRange(value=0.0, maxValue=0.0)" }
+      |Box:
+      |${BLANK}Box { test-tag:"parent" }
+      |${BLANK}╰─LazyColumn { vertical-scroll-axis-range:"ScrollAxisRange(value=0.0, maxValue=0.0)", test-tag:"list" }
       |${BLANK}  ├─<subcomposition of LazyColumn>
       |${BLANK}  │ ╰─SkippableItem { test-tag:"child:1" }
       |${BLANK}  ├─<subcomposition of LazyColumn>
@@ -612,6 +629,8 @@ class ComposeUiTest {
 
   @Test fun scanningSubcomposition_includesSize() {
     composeRule.setContent {
+      currentComposer.collectParameterInformation()
+
       // Convert 10 px to DP, since output is always in px.
       val sizeDp = with(LocalDensity.current) { 10.toDp() }
 
@@ -646,8 +665,8 @@ class ComposeUiTest {
 
     assertThat(hierarchy).isEqualTo(
       """
-      |CompositionLocalProvider:
-      |${BLANK}CompositionLocalProvider { 10×30px, test-tag:"parent" }
+      |Box:
+      |${BLANK}Box { 10×30px, test-tag:"parent" }
       |${BLANK}╰─MultipleSubcompositionLayout { 10×30px, test-tag:"subcompose-layout" }
       |${BLANK}  ├─<subcomposition of MultipleSubcompositionLayout>
       |${BLANK}  │ ├─Box { 10×10px, test-tag:"child1" }

--- a/compose-unsupported-tests/build.gradle.kts
+++ b/compose-unsupported-tests/build.gradle.kts
@@ -31,7 +31,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = Versions.Compose
+    kotlinCompilerExtensionVersion = Versions.ComposeCompiler
   }
 
   packaging {

--- a/radiography/src/main/java/radiography/ExperimentalRadiographyComposeApi.kt
+++ b/radiography/src/main/java/radiography/ExperimentalRadiographyComposeApi.kt
@@ -4,4 +4,5 @@ package radiography
   message = "This API is experimental, may only work with a specific version of Compose, " +
     "and may change or break at any time. Use with caution."
 )
+@Retention(AnnotationRetention.BINARY)
 public annotation class ExperimentalRadiographyComposeApi

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -8,7 +8,6 @@ import android.widget.TextView
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.layout.LayoutIdParentData
 import androidx.compose.ui.semantics.ScrollAxisRange
-import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsProperties.EditableText
 import androidx.compose.ui.semantics.SemanticsProperties.Text

--- a/radiography/src/main/java/radiography/ViewStateRenderers.kt
+++ b/radiography/src/main/java/radiography/ViewStateRenderers.kt
@@ -72,11 +72,10 @@ public object ViewStateRenderers {
 
       // Semantics
       composeView
-        .modifiers
-        .filterIsInstance<SemanticsModifier>()
+        .semanticsConfigurations
         // Technically there can be multiple semantic modifiers on a single node, so read them
         // all.
-        .flatMap { semantics -> semantics.semanticsConfiguration }
+        .flatten()
         .forEach { (key, value) ->
           when (key) {
             SemanticsProperties.TestTag -> appendLabeledValue("test-tag", value)

--- a/radiography/src/main/java/radiography/internal/Semantics.kt
+++ b/radiography/src/main/java/radiography/internal/Semantics.kt
@@ -1,6 +1,5 @@
 package radiography.internal
 
-import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import radiography.ScannableView.ComposeView
 import radiography.ExperimentalRadiographyComposeApi
@@ -10,7 +9,6 @@ import radiography.ExperimentalRadiographyComposeApi
 internal fun ComposeView.findTestTags(): Sequence<String> {
   return semanticsConfigurations
     .asSequence()
-//    .filterIsInstance<SemanticsModifier>()
     .flatMap { semantics ->
       semantics.filter { it.key == SemanticsProperties.TestTag }
     }

--- a/radiography/src/main/java/radiography/internal/Semantics.kt
+++ b/radiography/src/main/java/radiography/internal/Semantics.kt
@@ -8,12 +8,11 @@ import radiography.ExperimentalRadiographyComposeApi
 /** Returns all tag strings set on the composable via `Modifier.testTag`. */
 @OptIn(ExperimentalRadiographyComposeApi::class)
 internal fun ComposeView.findTestTags(): Sequence<String> {
-  return modifiers
+  return semanticsConfigurations
     .asSequence()
-    .filterIsInstance<SemanticsModifier>()
+//    .filterIsInstance<SemanticsModifier>()
     .flatMap { semantics ->
-      semantics.semanticsConfiguration.asSequence()
-        .filter { it.key == SemanticsProperties.TestTag }
+      semantics.filter { it.key == SemanticsProperties.TestTag }
     }
     .mapNotNull { it.value as? String }
 }

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
 }
 
 /** Use a separate property for the sample so we can test with different versions easily. */
-val sampleComposeVersion = "1.5.3"
+val sampleComposeVersion = "1.6.8"
+val sampleComposeCompilerVersion = "1.5.3"
 
 android {
   compileSdk = 34
@@ -28,7 +29,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = sampleComposeVersion
+    kotlinCompilerExtensionVersion = sampleComposeCompilerVersion
   }
 
   packaging {

--- a/sample-compose/src/main/java/com/squareup/radiography/sample/compose/MainActivity.kt
+++ b/sample-compose/src/main/java/com/squareup/radiography/sample/compose/MainActivity.kt
@@ -3,11 +3,13 @@ package com.squareup.radiography.sample.compose
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.currentComposer
 
 class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
+      currentComposer.collectParameterInformation()
       ComposeSampleApp()
     }
   }


### PR DESCRIPTION
This PR makes a few updates to get all tests passing on the latest compose 1.7 beta version, addressing some changes for 1.6 and 1.7.

First, it addresses an issue due to 1.6 (https://github.com/square/radiography/issues/159) by adding calls to `currentComposer.collectParameterInformation()` within test functions. This fixes tests within Radiography to make the project compatible, but does not address the potential of providing some functionality to end users to apply this easily. It is a fairly easy function to add, so perhaps the documentation should just be updated to included a note about this (I didn't attempt to do that in this PR though)

The other main fix is to the `findTestTags` function and compose renderer - these broke because they were trying to read semantic information from the compose modifiers; in newer versions of compose the semantics information is only present in semantic nodes. I had previously updated Radiography to expose that data for Compose 1.5 (https://github.com/square/radiography/pull/157) but these usage sites hadn't been updated and had broken.