### PR TITLE
Release 2.10 [CLF-221]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ Change Log
 ==========
 
 
+Version 2.10
+------------
+
+_2026-07-23_
+
+* Fix the `radiography` stoic-plugin launcher script when invoked via a symlink, e.g. from a Homebrew install ([#192](https://github.com/square/radiography/pull/192)).
+
 Version 2.9
 -----------
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the `radiography` dependency to your app's `build.gradle` file:
 
 ```gradle
 dependencies {
-  implementation 'com.squareup.radiography:radiography:2.9'
+  implementation 'com.squareup.radiography:radiography:2.10'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.radiography
-VERSION_NAME=2.10-SNAPSHOT
+VERSION_NAME=2.10
 
 POM_DESCRIPTION=Pretty printing of view hierarchies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.radiography
-VERSION_NAME=2.10
+VERSION_NAME=2.11-SNAPSHOT
 
 POM_DESCRIPTION=Pretty printing of view hierarchies
 


### PR DESCRIPTION
Releases Radiography 2.10 and prepares the next development iteration.

- Changelog entry for 2.10: fix the `radiography` stoic-plugin launcher script when invoked via a symlink (#192)
- Bump version to 2.10 in `gradle.properties` and README
- Bump to 2.11-SNAPSHOT for next development iteration

The v2.10 tag has been published: [Maven Central publish workflow run](https://github.com/block/radiography/actions/runs/30058933951) succeeded and the [GitHub release](https://github.com/block/radiography/releases/tag/v2.10) is live.

Linear: CLF-221

🤖 Generated with [Claude Code](https://claude.com/claude-code)